### PR TITLE
Add support for getting logs

### DIFF
--- a/api/models/app.go
+++ b/api/models/app.go
@@ -12,6 +12,7 @@ var (
 	ErrAppsList           = errors.New("Could not list apps from datastore")
 	ErrAppsNotFound       = errors.New("App not found")
 	ErrAppNothingToUpdate = errors.New("Nothing to update")
+	ErrAppLog             = errors.New("Could not retrieve log")
 )
 
 type App struct {
@@ -31,4 +32,8 @@ func (a *App) Validate() error {
 }
 
 type AppFilter struct {
+}
+
+type AppLog struct {
+	Log string `json:"log"`
 }

--- a/api/models/config.go
+++ b/api/models/config.go
@@ -8,6 +8,7 @@ type Config struct {
 		Level  string `json:"level"`
 		Prefix string `json:"prefix"`
 	}
+	PapertrailToken string `json:"papertrail_token"`
 }
 
 func (c *Config) Validate() error {

--- a/api/server/router/apps_log.go
+++ b/api/server/router/apps_log.go
@@ -1,0 +1,68 @@
+package router
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/gin-gonic/gin"
+	"github.com/iron-io/functions/api/models"
+)
+
+type ptrailResponse struct {
+	MinID  uint64        `json:"min_id,string"`
+	MaxID  uint64        `json:"max_id,string"`
+	Events []ptrailEvent `json:"events"`
+}
+
+type ptrailEvent struct {
+	ReceivedAt time.Time `json:"received_at"`
+	Message    string    `json:"message"`
+	ID         uint64    `json:"id,string"`
+}
+
+func handleAppLog(c *gin.Context) {
+	cfg := c.MustGet("config").(*models.Config)
+	log := c.MustGet("log").(logrus.FieldLogger)
+
+	appName := c.Param("app")
+
+	url := fmt.Sprintf("https://papertrailapp.com/api/v1/events/search.json?q=program:%s", appName)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+	}
+	req.Header.Set("X-Papertrail-Token", cfg.PapertrailToken)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		log.WithError(err).Error("Papertrail request failed")
+		c.JSON(http.StatusInternalServerError, simpleError(models.ErrAppLog))
+		return
+	}
+	if resp.StatusCode != 200 {
+		log.WithField("http_status", resp.StatusCode).Error("Papertrail request returned bad status")
+		c.JSON(http.StatusInternalServerError, simpleError(models.ErrAppLog))
+		return
+	}
+
+	var presp ptrailResponse
+	dec := json.NewDecoder(resp.Body)
+	err = dec.Decode(&presp)
+	if err != nil {
+		log.WithError(err).Error("failed to decode Papertrail response")
+		c.JSON(http.StatusInternalServerError, simpleError(models.ErrAppLog))
+		return
+	}
+
+	// TODO: could reduce allocations here in a variety of ways if needed
+	var buf bytes.Buffer
+	for _, ev := range presp.Events {
+		fmt.Fprintf(&buf, "%v: %s\n", ev.ReceivedAt, ev.Message)
+	}
+	appLog := &models.AppLog{
+		Log: buf.String(),
+	}
+	c.JSON(http.StatusOK, appLog)
+}

--- a/api/server/router/router.go
+++ b/api/server/router/router.go
@@ -18,6 +18,8 @@ func Start(engine *gin.Engine) {
 		v1.POST("/apps/:app", handleAppUpdate)
 		v1.DELETE("/apps/:app", handleAppDestroy)
 
+		v1.GET("/apps/:app/log", handleAppLog)
+
 		apps := v1.Group("/apps/:app")
 		{
 			apps.GET("/routes", handleRouteList)

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ func main() {
 	config := &models.Config{}
 	config.DatabaseURL = os.Getenv("DB")
 	config.API = os.Getenv("API")
+	config.PapertrailToken = os.Getenv("PT_TOKEN")
 
 	err := config.Validate()
 	if err != nil {


### PR DESCRIPTION
This commit adds an endpoint:

```
/v1/apps/:app/log
```

This endpoint returns a JSON response that looks like this:

```
{"log": "2016-07-29 11:59:39 +1200 NZST: log line 1\n2016-07-29 11:59:39 +1200 NZST: log line 2\n"}
```

Logs are pulled from Papertrail, and the Papertrail token is configured via the
environment variable `PT_TOKEN`.

There's nothing here yet for actually sending the logs to Papertrail or
categorizing them as I don't want to conflict with pull request #26.
