### PR TITLE
Turning datastore, router and config globals

### DIFF
--- a/api/models/config.go
+++ b/api/models/config.go
@@ -2,7 +2,6 @@ package models
 
 type Config struct {
 	DatabaseURL string `json:"db"`
-	API         string `json:"api"`
 	Logging     struct {
 		To     string `json:"to"`
 		Level  string `json:"level"`

--- a/api/server/router/apps_create.go
+++ b/api/server/router/apps_create.go
@@ -6,10 +6,10 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/gin-gonic/gin"
 	"github.com/iron-io/functions/api/models"
+	"github.com/iron-io/functions/api/server"
 )
 
 func handleAppCreate(c *gin.Context) {
-	store := c.MustGet("store").(models.Datastore)
 	log := c.MustGet("log").(logrus.FieldLogger)
 
 	wapp := &models.AppWrapper{}
@@ -33,7 +33,7 @@ func handleAppCreate(c *gin.Context) {
 		return
 	}
 
-	app, err := store.StoreApp(wapp.App)
+	app, err := api.Datastore.StoreApp(wapp.App)
 	if err != nil {
 		log.WithError(err).Debug(models.ErrAppsCreate)
 		c.JSON(http.StatusInternalServerError, simpleError(models.ErrAppsCreate))

--- a/api/server/router/apps_delete.go
+++ b/api/server/router/apps_delete.go
@@ -6,14 +6,14 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/gin-gonic/gin"
 	"github.com/iron-io/functions/api/models"
+	"github.com/iron-io/functions/api/server"
 )
 
 func handleAppDelete(c *gin.Context) {
-	store := c.MustGet("store").(models.Datastore)
 	log := c.MustGet("log").(logrus.FieldLogger)
 
 	appName := c.Param("app")
-	err := store.RemoveApp(appName)
+	err := api.Datastore.RemoveApp(appName)
 
 	if err != nil {
 		log.WithError(err).Debug(models.ErrAppsRemoving)

--- a/api/server/router/apps_get.go
+++ b/api/server/router/apps_get.go
@@ -6,14 +6,14 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/gin-gonic/gin"
 	"github.com/iron-io/functions/api/models"
+	"github.com/iron-io/functions/api/server"
 )
 
 func handleAppGet(c *gin.Context) {
-	store := c.MustGet("store").(models.Datastore)
 	log := c.MustGet("log").(logrus.FieldLogger)
 
 	appName := c.Param("app")
-	app, err := store.GetApp(appName)
+	app, err := api.Datastore.GetApp(appName)
 
 	if err != nil {
 		log.WithError(err).Error(models.ErrAppsGet)

--- a/api/server/router/apps_list.go
+++ b/api/server/router/apps_list.go
@@ -6,15 +6,15 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/gin-gonic/gin"
 	"github.com/iron-io/functions/api/models"
+	"github.com/iron-io/functions/api/server"
 )
 
 func handleAppList(c *gin.Context) {
-	store := c.MustGet("store").(models.Datastore)
 	log := c.MustGet("log").(logrus.FieldLogger)
 
 	filter := &models.AppFilter{}
 
-	apps, err := store.GetApps(filter)
+	apps, err := api.Datastore.GetApps(filter)
 	if err != nil {
 		log.WithError(err).Debug(models.ErrAppsList)
 		c.JSON(http.StatusInternalServerError, simpleError(models.ErrAppsList))

--- a/api/server/router/apps_test.go
+++ b/api/server/router/apps_test.go
@@ -7,11 +7,10 @@ import (
 	"testing"
 
 	"github.com/iron-io/functions/api/models"
-	"github.com/iron-io/functions/api/server/datastore"
 )
 
 func TestAppCreate(t *testing.T) {
-	router := testRouter(&datastore.Mock{}, &models.Config{})
+	router := testRouter()
 
 	for i, test := range []struct {
 		path          string
@@ -51,7 +50,7 @@ func TestAppCreate(t *testing.T) {
 }
 
 func TestAppDelete(t *testing.T) {
-	router := testRouter(&datastore.Mock{}, &models.Config{})
+	router := testRouter()
 
 	for i, test := range []struct {
 		path          string
@@ -81,7 +80,7 @@ func TestAppDelete(t *testing.T) {
 }
 
 func TestAppList(t *testing.T) {
-	router := testRouter(&datastore.Mock{}, &models.Config{})
+	router := testRouter()
 
 	for i, test := range []struct {
 		path          string
@@ -110,7 +109,7 @@ func TestAppList(t *testing.T) {
 }
 
 func TestAppGet(t *testing.T) {
-	router := testRouter(&datastore.Mock{}, &models.Config{})
+	router := testRouter()
 
 	for i, test := range []struct {
 		path          string
@@ -139,7 +138,7 @@ func TestAppGet(t *testing.T) {
 }
 
 func TestAppUpdate(t *testing.T) {
-	router := testRouter(&datastore.Mock{}, &models.Config{})
+	router := testRouter()
 
 	for i, test := range []struct {
 		path          string

--- a/api/server/router/apps_update.go
+++ b/api/server/router/apps_update.go
@@ -9,7 +9,6 @@ import (
 )
 
 func handleAppUpdate(c *gin.Context) {
-	// store := c.MustGet("store").(models.Datastore)
 	log := c.MustGet("log").(logrus.FieldLogger)
 
 	app := &models.App{}
@@ -33,7 +32,7 @@ func handleAppUpdate(c *gin.Context) {
 		return
 	}
 
-	// app, err := store.StoreApp(wapp.App)
+	// app, err := api.Datastore.StoreApp(wapp.App)
 	// if err != nil {
 	// 	log.WithError(err).Debug(models.ErrAppsCreate)
 	// 	c.JSON(http.StatusInternalServerError, simpleError(models.ErrAppsCreate))

--- a/api/server/router/helpers.go
+++ b/api/server/router/helpers.go
@@ -11,27 +11,12 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/gin-gonic/gin"
 	"github.com/iron-io/functions/api/models"
-	"github.com/iron-io/functions/api/server/datastore"
 )
 
-func testRouter(ds models.Datastore, config *models.Config) *gin.Engine {
+func testRouter() *gin.Engine {
 	r := gin.Default()
 	r.Use(func(c *gin.Context) {
-		c.Set("store", ds)
 		c.Set("log", logrus.WithFields(logrus.Fields{}))
-		c.Set("config", config)
-		c.Next()
-	})
-	Start(r)
-	return r
-}
-
-func testRouterWithDefault() *gin.Engine {
-	r := gin.Default()
-	r.Use(func(c *gin.Context) {
-		c.Set("store", &datastore.Mock{})
-		c.Set("log", logrus.WithFields(logrus.Fields{}))
-		c.Set("config", &models.Config{})
 		c.Next()
 	})
 	Start(r)

--- a/api/server/router/routes_create.go
+++ b/api/server/router/routes_create.go
@@ -6,10 +6,10 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/gin-gonic/gin"
 	"github.com/iron-io/functions/api/models"
+	"github.com/iron-io/functions/api/server"
 )
 
 func handleRouteCreate(c *gin.Context) {
-	store := c.MustGet("store").(models.Datastore)
 	log := c.MustGet("log").(logrus.FieldLogger)
 
 	var wroute models.RouteWrapper
@@ -35,7 +35,7 @@ func handleRouteCreate(c *gin.Context) {
 		return
 	}
 
-	app, err := store.GetApp(wroute.Route.AppName)
+	app, err := api.Datastore.GetApp(wroute.Route.AppName)
 	if err != nil {
 		log.WithError(err).Error(models.ErrAppsGet)
 		c.JSON(http.StatusInternalServerError, simpleError(models.ErrAppsGet))
@@ -49,7 +49,7 @@ func handleRouteCreate(c *gin.Context) {
 			return
 		}
 
-		app, err = store.StoreApp(newapp)
+		app, err = api.Datastore.StoreApp(newapp)
 		if err != nil {
 			log.WithError(err).Error(models.ErrAppsCreate)
 			c.JSON(http.StatusInternalServerError, simpleError(models.ErrAppsCreate))
@@ -57,7 +57,7 @@ func handleRouteCreate(c *gin.Context) {
 		}
 	}
 
-	route, err := store.StoreRoute(wroute.Route)
+	route, err := api.Datastore.StoreRoute(wroute.Route)
 	if err != nil {
 		log.WithError(err).Error(models.ErrRoutesCreate)
 		c.JSON(http.StatusInternalServerError, simpleError(models.ErrRoutesCreate))

--- a/api/server/router/routes_delete.go
+++ b/api/server/router/routes_delete.go
@@ -6,15 +6,15 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/gin-gonic/gin"
 	"github.com/iron-io/functions/api/models"
+	"github.com/iron-io/functions/api/server"
 )
 
 func handleRouteDelete(c *gin.Context) {
-	store := c.MustGet("store").(models.Datastore)
 	log := c.MustGet("log").(logrus.FieldLogger)
 
 	appName := c.Param("app")
 	routeName := c.Param("route")
-	err := store.RemoveRoute(appName, routeName)
+	err := api.Datastore.RemoveRoute(appName, routeName)
 
 	if err != nil {
 		log.WithError(err).Debug(models.ErrRoutesRemoving)

--- a/api/server/router/routes_get.go
+++ b/api/server/router/routes_get.go
@@ -6,16 +6,16 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/gin-gonic/gin"
 	"github.com/iron-io/functions/api/models"
+	"github.com/iron-io/functions/api/server"
 )
 
 func handleRouteGet(c *gin.Context) {
-	store := c.MustGet("store").(models.Datastore)
 	log := c.MustGet("log").(logrus.FieldLogger)
 
 	appName := c.Param("app")
 	routeName := c.Param("route")
 
-	route, err := store.GetRoute(appName, routeName)
+	route, err := api.Datastore.GetRoute(appName, routeName)
 	if err != nil {
 		log.WithError(err).Error(models.ErrRoutesGet)
 		c.JSON(http.StatusInternalServerError, simpleError(models.ErrRoutesGet))

--- a/api/server/router/routes_list.go
+++ b/api/server/router/routes_list.go
@@ -6,10 +6,10 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/gin-gonic/gin"
 	"github.com/iron-io/functions/api/models"
+	"github.com/iron-io/functions/api/server"
 )
 
 func handleRouteList(c *gin.Context) {
-	store := c.MustGet("store").(models.Datastore)
 	log := c.MustGet("log").(logrus.FieldLogger)
 
 	appName := c.Param("app")
@@ -18,7 +18,7 @@ func handleRouteList(c *gin.Context) {
 		AppName: appName,
 	}
 
-	routes, err := store.GetRoutes(filter)
+	routes, err := api.Datastore.GetRoutes(filter)
 	if err != nil {
 		log.WithError(err).Error(models.ErrRoutesGet)
 		c.JSON(http.StatusInternalServerError, simpleError(models.ErrRoutesGet))

--- a/api/server/router/routes_test.go
+++ b/api/server/router/routes_test.go
@@ -7,11 +7,10 @@ import (
 	"testing"
 
 	"github.com/iron-io/functions/api/models"
-	"github.com/iron-io/functions/api/server/datastore"
 )
 
 func TestRouteCreate(t *testing.T) {
-	router := testRouter(&datastore.Mock{}, &models.Config{})
+	router := testRouter()
 
 	for i, test := range []struct {
 		path          string
@@ -52,7 +51,7 @@ func TestRouteCreate(t *testing.T) {
 }
 
 func TestRouteDelete(t *testing.T) {
-	router := testRouter(&datastore.Mock{}, &models.Config{})
+	router := testRouter()
 
 	for i, test := range []struct {
 		path          string
@@ -82,7 +81,7 @@ func TestRouteDelete(t *testing.T) {
 }
 
 func TestRouteList(t *testing.T) {
-	router := testRouter(&datastore.Mock{}, &models.Config{})
+	router := testRouter()
 
 	for i, test := range []struct {
 		path          string
@@ -111,7 +110,7 @@ func TestRouteList(t *testing.T) {
 }
 
 func TestRouteGet(t *testing.T) {
-	router := testRouter(&datastore.Mock{}, &models.Config{})
+	router := testRouter()
 
 	for i, test := range []struct {
 		path          string
@@ -140,7 +139,7 @@ func TestRouteGet(t *testing.T) {
 }
 
 func TestRouteUpdate(t *testing.T) {
-	router := testRouter(&datastore.Mock{}, &models.Config{})
+	router := testRouter()
 
 	for i, test := range []struct {
 		path          string

--- a/api/server/router/routes_update.go
+++ b/api/server/router/routes_update.go
@@ -6,10 +6,10 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/gin-gonic/gin"
 	"github.com/iron-io/functions/api/models"
+	"github.com/iron-io/functions/api/server"
 )
 
 func handleRouteUpdate(c *gin.Context) {
-	store := c.MustGet("store").(models.Datastore)
 	log := c.MustGet("log").(logrus.FieldLogger)
 
 	var wroute models.RouteWrapper
@@ -36,7 +36,7 @@ func handleRouteUpdate(c *gin.Context) {
 		return
 	}
 
-	route, err := store.StoreRoute(wroute.Route)
+	route, err := api.Datastore.StoreRoute(wroute.Route)
 	if err != nil {
 		log.WithError(err).Debug(models.ErrAppsCreate)
 		c.JSON(http.StatusInternalServerError, simpleError(models.ErrAppsCreate))

--- a/api/server/router/runner.go
+++ b/api/server/router/runner.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/iron-io/functions/api/models"
 	"github.com/iron-io/functions/api/runner"
+	"github.com/iron-io/functions/api/server"
 )
 
 func handleRunner(c *gin.Context) {
@@ -21,7 +22,6 @@ func handleRunner(c *gin.Context) {
 	}
 
 	log := c.MustGet("log").(logrus.FieldLogger)
-	store := c.MustGet("store").(models.Datastore)
 
 	var err error
 
@@ -64,7 +64,7 @@ func handleRunner(c *gin.Context) {
 
 	log.WithFields(logrus.Fields{"app": appName, "path": route}).Debug("Finding route on datastore")
 
-	routes, err := store.GetRoutes(filter)
+	routes, err := api.Datastore.GetRoutes(filter)
 	if err != nil {
 		log.WithError(err).Error(models.ErrRoutesList)
 		c.JSON(http.StatusInternalServerError, simpleError(models.ErrRoutesList))

--- a/api/server/router/runner_test.go
+++ b/api/server/router/runner_test.go
@@ -7,11 +7,12 @@ import (
 	"testing"
 
 	"github.com/iron-io/functions/api/models"
+	"github.com/iron-io/functions/api/server"
 	"github.com/iron-io/functions/api/server/datastore"
 )
 
 func TestRouteRunnerGet(t *testing.T) {
-	router := testRouter(&datastore.Mock{}, &models.Config{})
+	router := testRouter()
 
 	for i, test := range []struct {
 		path          string
@@ -43,7 +44,7 @@ func TestRouteRunnerGet(t *testing.T) {
 }
 
 func TestRouteRunnerPost(t *testing.T) {
-	router := testRouter(&datastore.Mock{}, &models.Config{})
+	router := testRouter()
 
 	for i, test := range []struct {
 		path          string
@@ -76,12 +77,14 @@ func TestRouteRunnerPost(t *testing.T) {
 }
 
 func TestRouteRunnerExecution(t *testing.T) {
-	router := testRouter(&datastore.Mock{
+	api.Datastore = &datastore.Mock{
 		FakeRoutes: []*models.Route{
 			{Path: "/myroute", Image: "iron/hello", Headers: map[string][]string{"X-Function": []string{"Test"}}},
 			{Path: "/myerror", Image: "iron/error", Headers: map[string][]string{"X-Function": []string{"Test"}}},
 		},
-	}, &models.Config{})
+	}
+
+	router := testRouter()
 
 	for i, test := range []struct {
 		path            string

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"path"
 
@@ -9,20 +10,11 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/iron-io/functions/api/models"
 	"github.com/iron-io/functions/api/server/datastore"
-	"github.com/iron-io/functions/api/server/router"
 )
 
-type Server struct {
-	router *gin.Engine
-	cfg    *models.Config
-}
-
-func New(config *models.Config) *Server {
-	return &Server{
-		router: gin.Default(),
-		cfg:    config,
-	}
-}
+var Config = &models.Config{}
+var Datastore models.Datastore = &datastore.Mock{}
+var Router *gin.Engine
 
 func extractFields(c *gin.Context) logrus.Fields {
 	fields := logrus.Fields{"action": path.Base(c.HandlerName())}
@@ -32,17 +24,19 @@ func extractFields(c *gin.Context) logrus.Fields {
 	return fields
 }
 
-func (s *Server) Start() {
-	if s.cfg.DatabaseURL == "" {
+func Start() {
+	err := Config.Validate()
+	if err != nil {
+		logrus.WithError(err).Fatalln("Invalid config.")
+	}
+	log.Printf("config: %+v", Config)
+
+	if Config.DatabaseURL == "" {
 		cwd, _ := os.Getwd()
-		s.cfg.DatabaseURL = fmt.Sprintf("bolt://%s/bolt.db?bucket=funcs", cwd)
+		Config.DatabaseURL = fmt.Sprintf("bolt://%s/bolt.db?bucket=funcs", cwd)
 	}
 
-	if s.cfg.API == "" {
-		s.cfg.API = "http://localhost:8080"
-	}
-
-	ds, err := datastore.New(s.cfg.DatabaseURL)
+	Datastore, err = datastore.New(Config.DatabaseURL)
 	if err != nil {
 		logrus.WithError(err).Fatalln("Invalid DB url.")
 	}
@@ -50,15 +44,10 @@ func (s *Server) Start() {
 	logrus.SetOutput(os.Stdout)
 	logrus.SetLevel(logrus.DebugLevel)
 
-	s.router.Use(func(c *gin.Context) {
-		c.Set("config", s.cfg)
-		c.Set("store", ds)
+	Router = gin.Default()
+
+	Router.Use(func(c *gin.Context) {
 		c.Set("log", logrus.WithFields(extractFields(c)))
 		c.Next()
 	})
-
-	router.Start(s.router)
-
-	// Default to :8080
-	s.router.Run()
 }

--- a/main.go
+++ b/main.go
@@ -1,31 +1,15 @@
-/*
-
-For keeping a minimum running, perhaps when doing a routing table update, if destination hosts are all
- expired or about to expire we start more.
-
-*/
-
 package main
 
 import (
 	"os"
 
-	log "github.com/Sirupsen/logrus"
-	"github.com/iron-io/functions/api/models"
+	"github.com/hollowcms/hollow/api/router"
 	"github.com/iron-io/functions/api/server"
 )
 
 func main() {
-	config := &models.Config{}
-	config.DatabaseURL = os.Getenv("DB")
-	config.API = os.Getenv("API")
-
-	err := config.Validate()
-	if err != nil {
-		log.WithError(err).Fatalln("Invalid config.")
-	}
-	log.Printf("config: %+v", config)
-
-	srv := api.New(config)
-	srv.Start()
+	api.Config.DatabaseURL = os.Getenv("DB")
+	api.Start()
+	router.Start(api.Router)
+	api.Router.Run()
 }


### PR DESCRIPTION
Running all tests with `go test ./...` still breaks until this issue is solved: #36 
But if run one by one it works

@treeder 
Closes: #34 
