### PR TITLE
Route filter improvement

### DIFF
--- a/api/datastore/bolt_test.go
+++ b/api/datastore/bolt_test.go
@@ -122,7 +122,19 @@ func TestBolt(t *testing.T) {
 	}
 
 	// Testing list routes
-	routes, err := ds.GetRoutes(&models.RouteFilter{AppName: testApp.Name})
+	routes, err := ds.GetRoutesByApp(testApp.Name, &models.RouteFilter{})
+	if err != nil {
+		t.Fatalf("Test GetRoutes: error: %s", err)
+	}
+	if len(routes) == 0 {
+		t.Fatal("Test GetRoutes: expected result count to be greater than 0")
+	}
+	if routes[0].Path != testRoute.Path {
+		t.Fatalf("Test GetRoutes: expected `app.Name` to be `%s` but it was `%s`", testRoute.Path, routes[0].Path)
+	}
+
+	// Testing list routes
+	routes, err = ds.GetRoutes(&models.RouteFilter{Image: testRoute.Image})
 	if err != nil {
 		t.Fatalf("Test GetRoutes: error: %s", err)
 	}

--- a/api/datastore/mock.go
+++ b/api/datastore/mock.go
@@ -33,6 +33,10 @@ func (m *Mock) GetRoutes(routeFilter *models.RouteFilter) ([]*models.Route, erro
 	return m.FakeRoutes, nil
 }
 
+func (m *Mock) GetRoutesByApp(appName string, routeFilter *models.RouteFilter) ([]*models.Route, error) {
+	return m.FakeRoutes, nil
+}
+
 func (m *Mock) StoreRoute(route *models.Route) (*models.Route, error) {
 	return m.FakeRoute, nil
 }

--- a/api/datastore/postgres/postgres.go
+++ b/api/datastore/postgres/postgres.go
@@ -263,6 +263,32 @@ func (ds *PostgresDatastore) GetRoutes(filter *models.RouteFilter) ([]*models.Ro
 	return res, nil
 }
 
+func (ds *PostgresDatastore) GetRoutesByApp(appName string, filter *models.RouteFilter) ([]*models.Route, error) {
+	res := []*models.Route{}
+	filter.AppName = appName
+	filterQuery := buildFilterQuery(filter)
+	rows, err := ds.db.Query(fmt.Sprintf("%s %s", routeSelector, filterQuery))
+	// todo: check for no rows so we don't respond with a sql 500 err
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var route models.Route
+		err := scanRoute(rows, &route)
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, &route)
+
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
 func buildFilterQuery(filter *models.RouteFilter) string {
 	filterQuery := ""
 

--- a/api/models/datastore.go
+++ b/api/models/datastore.go
@@ -10,6 +10,7 @@ type Datastore interface {
 
 	GetRoute(appName, routeName string) (*Route, error)
 	GetRoutes(*RouteFilter) (routes []*Route, err error)
+	GetRoutesByApp(string, *RouteFilter) (routes []*Route, err error)
 	StoreRoute(*Route) (*Route, error)
 	RemoveRoute(appName, routeName string) error
 

--- a/api/server/routes_list.go
+++ b/api/server/routes_list.go
@@ -15,17 +15,20 @@ func handleRouteList(c *gin.Context) {
 	ctx := c.MustGet("ctx").(context.Context)
 	log := titancommon.Logger(ctx)
 
-	appName := c.Param("app")
-
-	filter := &models.RouteFilter{
-		AppName: appName,
-	}
+	filter := &models.RouteFilter{}
 
 	if img := c.Query("image"); img != "" {
 		filter.Image = img
 	}
 
-	routes, err := Api.Datastore.GetRoutes(filter)
+	var routes []*models.Route
+	var err error
+	if app := c.Param("app"); app != "" {
+		routes, err = Api.Datastore.GetRoutesByApp(app, filter)
+	} else {
+		routes, err = Api.Datastore.GetRoutes(filter)
+	}
+
 	if err != nil {
 		log.WithError(err).Error(models.ErrRoutesGet)
 		c.JSON(http.StatusInternalServerError, simpleError(models.ErrRoutesGet))

--- a/api/server/runner.go
+++ b/api/server/runner.go
@@ -88,13 +88,12 @@ func handleRunner(c *gin.Context) {
 	}
 
 	filter := &models.RouteFilter{
-		Path:    route,
-		AppName: appName,
+		Path: route,
 	}
 
 	log.WithFields(logrus.Fields{"app": appName, "path": route}).Debug("Finding route on datastore")
 
-	routes, err := Api.Datastore.GetRoutes(filter)
+	routes, err := Api.Datastore.GetRoutesByApp(appName, filter)
 	if err != nil {
 		log.WithError(err).Error(models.ErrRoutesList)
 		c.JSON(http.StatusInternalServerError, simpleError(models.ErrRoutesList))

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -113,6 +113,8 @@ func bindHandlers(engine *gin.Engine) {
 		v1.PUT("/apps/:app", handleAppUpdate)
 		v1.DELETE("/apps/:app", handleAppDelete)
 
+		v1.GET("/routes", handleRouteList)
+
 		apps := v1.Group("/apps/:app")
 		{
 			apps.GET("/routes", handleRouteList)


### PR DESCRIPTION
Added the possibility to search routes without the need of app name.
- Added the method GetRoutesByApp that look for routes inside specific app
- GetRoutes now doesn't search by app. (on BoltDB it iterates all routes of all apps)
- Added new route on gin: `/v1/routes`
- Applied those changes on `handleRunner` and `handleRouteList`
- Added test
  @treeder 

Note: need this for `iron fn deploy`
