### PR TITLE
[WIP] use dockerdriver.CheckImage func

### DIFF
--- a/api/runner/runner.go
+++ b/api/runner/runner.go
@@ -156,7 +156,6 @@ func (r *Runner) Run(ctx context.Context, cfg *Config) (drivers.RunResult, error
 	ctask := &containerTask{
 		ctx:    ctx,
 		cfg:    cfg,
-		auth:   &common.ConfigAuth{},
 		canRun: make(chan bool),
 	}
 
@@ -214,16 +213,11 @@ func (r *Runner) Run(ctx context.Context, cfg *Config) (drivers.RunResult, error
 
 func (r Runner) EnsureImageExists(ctx context.Context, cfg *Config) error {
 	ctask := &containerTask{
-		cfg:  cfg,
-		auth: &common.ConfigAuth{},
+		cfg: cfg,
 	}
 
-	closer, err := r.driver.Prepare(ctx, ctask)
-	if err != nil {
-		return err
-	}
-	closer.Close()
-	return nil
+	_, err := docker.CheckRegistry(ctask.Image(), ctask.DockerAuth())
+	return err
 }
 
 func selectDriver(driver string, env *common.Environment, conf *driverscommon.Config) (drivers.Driver, error) {

--- a/api/runner/task.go
+++ b/api/runner/task.go
@@ -3,16 +3,13 @@ package runner
 import (
 	"io"
 
-	"golang.org/x/net/context"
-
-	dockercli "github.com/fsouza/go-dockerclient"
-	"github.com/iron-io/runner/common"
+	"github.com/fsouza/go-dockerclient"
 	"github.com/iron-io/runner/drivers"
+	"golang.org/x/net/context"
 )
 
 type containerTask struct {
 	ctx    context.Context
-	auth   *common.ConfigAuth
 	cfg    *Config
 	canRun chan bool
 }
@@ -40,6 +37,5 @@ func (t *containerTask) WorkDir() string                    { return "" }
 func (t *containerTask) Close()                 {}
 func (t *containerTask) WriteStat(drivers.Stat) {}
 
-func (t *containerTask) DockerAuth() []dockercli.AuthConfiguration {
-	return t.auth.Auth(t.Image())
-}
+// FIXME: for now just use empty creds => public docker hub image
+func (t *containerTask) DockerAuth() docker.AuthConfiguration { return docker.AuthConfiguration{} }


### PR DESCRIPTION
EnsureImageExists is a subset of driver.Prepare as it stands. I don't quite
understand why the check is needed in any case:

for route creation why do we care if the image exists prior to letting it
land? the image could easily be removed from the hub/registry and be in the
same funky state where the route might exist in the api gateway but when a
new server tries to run it it's incapable, so that check doesn't seem a very
good gate (just a sanity check).

if enough agree about ^ we could remove EnsureImageExists on the whole. The
only change this patch makes is such that not only will the image exist, but
it's now more likely that we could actually run a task with that image since
driver.Prepare does some additional checks.

EnsureImageExists goes away as of https://github.com/iron-io/worker/pull/357 -- need to update deps after it lands
