### PR TITLE
Ensure supervisor restarts async worker regardless of number of failures

### DIFF
--- a/main.go
+++ b/main.go
@@ -80,6 +80,7 @@ func main() {
 	}
 
 	svr := &supervisor.Supervisor{
+		MaxRestarts: supervisor.AlwaysRestart,
 		Log: func(msg interface{}) {
 			log.Debug("supervisor: ", msg)
 		},


### PR DESCRIPTION
A manual test with several hundreds of routes revealed that the bootstrap
process could lead to a situation where HTTP interface is not yet ready
to receive async workers connections, thus making them fail.

This deals with such situation by forcing them to always restart.
Eventually, we'll need to figure out a different perhaps better
architecture to handle readiness protocol between these two moving parts.

cc: @seiflotfy - this is relevant for the changes you are doing in the router.
