### PR TITLE
fnctl: init - configuration over detection

### DIFF
--- a/fnctl/common.go
+++ b/fnctl/common.go
@@ -18,8 +18,6 @@ import (
 	"github.com/urfave/cli"
 )
 
-var errDockerFileNotFound = errors.New("no Dockerfile found for this function")
-
 func isFuncfile(path string, info os.FileInfo) bool {
 	if info.IsDir() {
 		return false

--- a/fnctl/funcfile.go
+++ b/fnctl/funcfile.go
@@ -14,9 +14,9 @@ import (
 
 var (
 	validfn = [...]string{
-		"function.yaml",
-		"function.yml",
-		"function.json",
+		"func.yaml",
+		"func.yml",
+		"func.json",
 	}
 
 	errUnexpectedFileFormat = errors.New("unexpected file format for function file")

--- a/fnctl/lambda.go
+++ b/fnctl/lambda.go
@@ -289,7 +289,7 @@ func createFunctionYaml(opts createImageOptions) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(filepath.Join(opts.Name, "function.yaml"), out, 0644)
+	return ioutil.WriteFile(filepath.Join(opts.Name, "func.yaml"), out, 0644)
 }
 
 type createImageOptions struct {
@@ -385,7 +385,7 @@ func createDockerfile(opts createImageOptions, files ...fileLike) error {
 		return err
 	}
 
-	fmt.Print("Creating function.yaml ... ")
+	fmt.Print("Creating func.yaml ... ")
 	if err := createFunctionYaml(opts); err != nil {
 		return err
 	}

--- a/fnctl/langs/base.go
+++ b/fnctl/langs/base.go
@@ -14,7 +14,7 @@ func GetLangHelper(lang string) (LangHelper, error) {
 }
 
 type LangHelper interface {
-	Entrypoint(filename string) (string, error)
+	Entrypoint() string
 	HasPreBuild() bool
 	PreBuild() error
 	AfterBuild() error

--- a/fnctl/langs/go.go
+++ b/fnctl/langs/go.go
@@ -10,10 +10,8 @@ import (
 type GoLangHelper struct {
 }
 
-func (lh *GoLangHelper) Entrypoint(filename string) (string, error) {
-	// uses a common binary name: func
-	// return fmt.Sprintf("./%v", filepath.Base(pwd)), nil
-	return "./func", nil
+func (lh *GoLangHelper) Entrypoint() string {
+	return "./func"
 }
 
 func (lh *GoLangHelper) HasPreBuild() bool {

--- a/fnctl/langs/node.go
+++ b/fnctl/langs/node.go
@@ -1,12 +1,10 @@
 package langs
 
-import "fmt"
-
 type NodeLangHelper struct {
 }
 
-func (lh *NodeLangHelper) Entrypoint(filename string) (string, error) {
-	return fmt.Sprintf("node %v", filename), nil
+func (lh *NodeLangHelper) Entrypoint() string {
+	return "node func.js"
 }
 
 func (lh *NodeLangHelper) HasPreBuild() bool {


### PR DESCRIPTION
This commit modifies how init detects runtime and entrypoints. It
assumes the following convention:

1 - All functions have a func.{lang} file - from which both
entrypoint and runtime are deduced.

2 - Entrypoints always are, depending on the language, "./func",
"{lang-exec} ./func.{lang}", "{lang-exec} ./func.{package}" (e.g.
Java's "func.jar" and PHP's "func.phar").