### PR TITLE
functions: common concurrency stream for sync and async

### DIFF
--- a/api/runner/async_runner.go
+++ b/api/runner/async_runner.go
@@ -140,7 +140,7 @@ func startAsyncRunners(ctx context.Context, url string, tasks chan TaskRequest, 
 			go func() {
 				defer wg.Done()
 				tresp := make(chan TaskResponse)
-				treq := TaskRequest{Prio: Low, Ctx: ctx, Config: getCfg(task), Response: tresp}
+				treq := TaskRequest{Ctx: ctx, Config: getCfg(task), Response: tresp}
 				tasks <- treq
 				resp := <-treq.Response
 				// Process Task

--- a/api/runner/async_runner.go
+++ b/api/runner/async_runner.go
@@ -9,9 +9,8 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"time"
-
 	"sync"
+	"time"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/iron-io/functions/api/models"
@@ -105,7 +104,6 @@ func isHostOpen(host string) bool {
 	return available
 }
 
-// TODO(ccirello): speed up async consumer - without overloading docker
 func startAsyncRunners(ctx context.Context, url string, tasks chan TaskRequest, rnr *Runner) {
 	var wg sync.WaitGroup
 	ctx, log := common.LoggerWithFields(ctx, logrus.Fields{"runner": "async"})

--- a/api/runner/async_runner.go
+++ b/api/runner/async_runner.go
@@ -113,7 +113,11 @@ func startAsyncRunners(ctx context.Context, url string, tasks chan TaskRequest, 
 			return
 
 		default:
-			rnr.waitAvailableMemoryAsync()
+			if !rnr.hasAvailableMemory() {
+				// TODO(ccirello): get rid of this time.Sleep through sync.Cond
+				time.Sleep(1 * time.Second)
+				continue
+			}
 			task, err := getTask(ctx, url)
 			if err != nil {
 				if err, ok := err.(net.Error); ok && err.Timeout() {

--- a/api/runner/async_runner.go
+++ b/api/runner/async_runner.go
@@ -103,7 +103,6 @@ func isHostOpen(host string) bool {
 	return available
 }
 
-// todo: not a big fan of this anonymous function for testing, should use an interface and make a Mock object for testing - TR
 func startAsyncRunners(ctx context.Context, url string, tasks chan TaskRequest) {
 	ctx, log := common.LoggerWithFields(ctx, logrus.Fields{"runner": "async"})
 	for {

--- a/api/runner/async_runner.go
+++ b/api/runner/async_runner.go
@@ -113,7 +113,8 @@ func startAsyncRunners(ctx context.Context, url string, tasks chan TaskRequest, 
 			return
 
 		default:
-			if !rnr.hasAvailableMemory() {
+			if !rnr.hasAsyncAvailableMemory() {
+				log.Debug("memory full")
 				time.Sleep(1 * time.Second)
 				continue
 			}

--- a/api/runner/async_runner.go
+++ b/api/runner/async_runner.go
@@ -114,7 +114,6 @@ func startAsyncRunners(ctx context.Context, url string, tasks chan TaskRequest, 
 
 		default:
 			if !rnr.hasAvailableMemory() {
-				// TODO(ccirello): get rid of this time.Sleep through sync.Cond
 				time.Sleep(1 * time.Second)
 				continue
 			}

--- a/api/runner/async_runner.go
+++ b/api/runner/async_runner.go
@@ -116,6 +116,7 @@ func startAsyncRunners(ctx context.Context, url string, tasks chan TaskRequest, 
 
 		default:
 			if !rnr.hasAvailableMemory() {
+				// TODO(ccirello): get rid of this time.Sleep through sync.Cond
 				time.Sleep(1 * time.Second)
 				continue
 			}

--- a/api/runner/async_runner.go
+++ b/api/runner/async_runner.go
@@ -115,11 +115,7 @@ func startAsyncRunners(ctx context.Context, url string, tasks chan TaskRequest, 
 			return
 
 		default:
-			if !rnr.hasAvailableMemory() {
-				// TODO(ccirello): get rid of this time.Sleep through sync.Cond
-				time.Sleep(1 * time.Second)
-				continue
-			}
+			rnr.waitAvailableMemoryAsync()
 			task, err := getTask(ctx, url)
 			if err != nil {
 				if err, ok := err.(net.Error); ok && err.Timeout() {

--- a/api/runner/async_runner_test.go
+++ b/api/runner/async_runner_test.go
@@ -10,7 +10,6 @@ import (
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
-	"sync"
 	"testing"
 	"time"
 
@@ -18,7 +17,6 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/iron-io/functions/api/models"
 	"github.com/iron-io/functions/api/mqs"
-	"github.com/iron-io/runner/drivers"
 )
 
 func setLogBuffer() *bytes.Buffer {
@@ -90,22 +88,6 @@ func getTestServer(mockTasks []*models.Task) *httptest.Server {
 	r.GET("/tasks", getHandler)
 	r.DELETE("/tasks", delHandler)
 	return httptest.NewServer(r)
-}
-
-var helloImage = "iron/hello"
-
-func TestRunTask(t *testing.T) {
-	mockTask := getMockTask()
-	mockTask.Image = &helloImage
-
-	result, err := runTask(context.Background(), &mockTask)
-	if err != nil {
-		t.Error(err)
-	}
-
-	if result.Status() != "success" {
-		t.Errorf("TestRunTask failed to execute runTask")
-	}
 }
 
 func TestGetTask(t *testing.T) {
@@ -206,19 +188,35 @@ func TestTasksrvURL(t *testing.T) {
 	}
 }
 
+func testRunner(t *testing.T) *Runner {
+	r, err := New(NewMetricLogger())
+	if err != nil {
+		t.Fatal("Test: failed to create new runner")
+	}
+	return r
+}
+
 func TestAsyncRunnersGracefulShutdown(t *testing.T) {
 	buf := setLogBuffer()
 	mockTask := getMockTask()
 	ts := getTestServer([]*models.Task{&mockTask})
 	defer ts.Close()
 
-	ctx, _ := context.WithTimeout(context.Background(), 2*time.Second)
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go startAsyncRunners(ctx, &wg, 0, ts.URL+"/tasks", func(ctx context.Context, task *models.Task) (drivers.RunResult, error) {
-		return nil, nil
-	})
-	wg.Wait()
+	tasks := make(chan TaskRequest)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	defer close(tasks)
+	go func() {
+		for t := range tasks {
+			t.Response <- TaskResponse{
+				Result: nil,
+				Err:    nil,
+			}
+
+		}
+	}()
+
+	startAsyncRunners(ctx, ts.URL+"/tasks", tasks)
 
 	if err := ctx.Err(); err != context.DeadlineExceeded {
 		t.Log(buf.String())

--- a/api/runner/async_runner_test.go
+++ b/api/runner/async_runner_test.go
@@ -216,7 +216,7 @@ func TestAsyncRunnersGracefulShutdown(t *testing.T) {
 		}
 	}()
 
-	startAsyncRunners(ctx, ts.URL+"/tasks", tasks)
+	startAsyncRunners(ctx, ts.URL+"/tasks", tasks, testRunner(t))
 
 	if err := ctx.Err(); err != context.DeadlineExceeded {
 		t.Log(buf.String())

--- a/api/runner/runner.go
+++ b/api/runner/runner.go
@@ -115,10 +115,11 @@ func (r *Runner) queueHandler() {
 	}
 }
 
-func (r *Runner) hasAvailableMemory() bool {
+func (r *Runner) hasAsyncAvailableMemory() bool {
 	r.usedMemMutex.RLock()
 	defer r.usedMemMutex.RUnlock()
-	return r.usedMem >= r.availableMem
+	// reserve at least half of the memory for sync
+	return (r.availableMem/2)-r.usedMem > 0
 }
 
 func (r *Runner) checkRequiredMem(req uint64) bool {

--- a/api/runner/runner.go
+++ b/api/runner/runner.go
@@ -118,7 +118,7 @@ func (r *Runner) queueHandler() {
 func (r *Runner) checkRequiredMem(req uint64) bool {
 	r.usedMemMutex.RLock()
 	defer r.usedMemMutex.RUnlock()
-	return r.availableMem-r.usedMem/int64(req)*1024*1024 > 0
+	return (r.availableMem-r.usedMem)/int64(req)*1024*1024 > 0
 }
 
 func (r *Runner) addUsedMem(used int64) {
@@ -136,7 +136,7 @@ func (r *Runner) checkMemAndUse(req uint64) bool {
 
 	used := int64(req) * 1024 * 1024
 
-	if r.availableMem-r.usedMem/used < 0 {
+	if (r.availableMem-r.usedMem)/used < 0 {
 		return false
 	}
 

--- a/api/runner/runner.go
+++ b/api/runner/runner.go
@@ -115,6 +115,12 @@ func (r *Runner) queueHandler() {
 	}
 }
 
+func (r *Runner) hasAvailableMemory() bool {
+	r.usedMemMutex.RLock()
+	defer r.usedMemMutex.RUnlock()
+	return r.usedMem >= r.availableMem
+}
+
 func (r *Runner) checkRequiredMem(req uint64) bool {
 	r.usedMemMutex.RLock()
 	defer r.usedMemMutex.RUnlock()

--- a/api/runner/worker.go
+++ b/api/runner/worker.go
@@ -1,0 +1,48 @@
+package runner
+
+import (
+	"context"
+	"sync"
+
+	"github.com/gin-gonic/gin"
+	"github.com/iron-io/functions/api/runner"
+	"github.com/iron-io/runner/drivers"
+)
+
+type TaskRequest struct {
+	Ctx      *gin.Context
+	Config   *runner.Config
+	Response chan TaskResponse
+}
+
+type TaskResponse struct {
+	Result drivers.RunResult
+	Err    error
+}
+
+func Worker(ctx context.Context, n int) {
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(ctx context.Context) {
+			defer wg.Done()
+			for {
+				select {
+				case <-ctx.Done():
+					break
+				case task := <-tasks:
+					result, err := Api.Runner.Run(task.Ctx, task.Config)
+
+					select {
+					case task.Response <- TaskResponse{result, err}:
+						close(task.Response)
+					default:
+					}
+				}
+			}
+		}(ctx)
+	}
+
+	wg.Wait()
+	<-ctx.Done()
+}

--- a/api/runner/worker.go
+++ b/api/runner/worker.go
@@ -42,3 +42,11 @@ func StartWorkers(ctx context.Context, rnr *Runner, tasks <-chan TaskRequest) {
 	}
 
 }
+
+func RunTask(tasks chan TaskRequest, ctx context.Context, cfg *Config) (drivers.RunResult, error) {
+	tresp := make(chan TaskResponse)
+	treq := TaskRequest{Ctx: ctx, Config: cfg, Response: tresp}
+	tasks <- treq
+	resp := <-treq.Response
+	return resp.Result, resp.Err
+}

--- a/api/runner/worker.go
+++ b/api/runner/worker.go
@@ -7,22 +7,7 @@ import (
 	"github.com/iron-io/runner/drivers"
 )
 
-type taskPriority int
-
-func (t taskPriority) String() string {
-	if t == High {
-		return "High"
-	}
-	return "Low"
-}
-
-const (
-	High taskPriority = iota
-	Low
-)
-
 type TaskRequest struct {
-	Prio     taskPriority
 	Ctx      context.Context
 	Config   *Config
 	Response chan TaskResponse
@@ -34,95 +19,26 @@ type TaskResponse struct {
 }
 
 // StartWorkers handle incoming tasks and spawns self-regulating container
-// workers. Internally it works with a priority queue, used to favor the
-// execution of Sync tasks over Async ones.
+// workers.
 func StartWorkers(ctx context.Context, rnr *Runner, tasks <-chan TaskRequest) {
 	var wg sync.WaitGroup
-	prioQ := &priotasksqueue{cond: &sync.Cond{L: &sync.Mutex{}}}
-
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		for {
-			select {
-			case <-ctx.Done():
-				prioQ.close()
-				return
-			case task := <-tasks:
-				if task.Prio == High {
-					prioQ.pushHigh(task)
-				} else if task.Prio == Low {
-					prioQ.pushLow(task)
-				}
-			}
-		}
-	}()
-
 	for {
-		task := prioQ.shift()
-		if task == nil {
+		select {
+		case <-ctx.Done():
+			wg.Wait()
 			return
+		case task := <-tasks:
+			wg.Add(1)
+			go func(task TaskRequest) {
+				defer wg.Done()
+				result, err := rnr.Run(task.Ctx, task.Config)
+				select {
+				case task.Response <- TaskResponse{result, err}:
+					close(task.Response)
+				default:
+				}
+			}(task)
 		}
-
-		wg.Add(1)
-		go func(task TaskRequest) {
-			defer wg.Done()
-			result, err := rnr.Run(task.Ctx, task.Config)
-			select {
-			case task.Response <- TaskResponse{result, err}:
-				close(task.Response)
-			default:
-			}
-		}(*task)
 	}
 
-	<-ctx.Done()
-	wg.Wait()
-}
-
-type priotasksqueue struct {
-	high, low []TaskRequest
-	cond      *sync.Cond
-	closed    bool
-}
-
-func (p *priotasksqueue) shift() *TaskRequest {
-	p.cond.L.Lock()
-	if len(p.high) == 0 && len(p.low) == 0 && !p.closed {
-		p.cond.Wait()
-	}
-	if p.closed {
-		p.cond.L.Unlock()
-		return nil
-	}
-
-	var v TaskRequest
-	if len(p.high) > 0 {
-		v, p.high = p.high[0], p.high[1:]
-	} else {
-		v, p.low = p.low[0], p.low[1:]
-	}
-	p.cond.L.Unlock()
-	return &v
-}
-
-func (p *priotasksqueue) pushHigh(task TaskRequest) {
-	p.cond.L.Lock()
-	p.high = append(p.high, task)
-	p.cond.L.Unlock()
-	p.cond.Signal()
-}
-
-func (p *priotasksqueue) pushLow(task TaskRequest) {
-	p.cond.L.Lock()
-	p.low = append(p.low, task)
-	p.cond.L.Unlock()
-	p.cond.Signal()
-}
-
-func (p *priotasksqueue) close() {
-	p.cond.L.Lock()
-	p.closed = true
-	p.cond.L.Unlock()
-	p.cond.Signal()
 }

--- a/api/runner/worker.go
+++ b/api/runner/worker.go
@@ -7,7 +7,22 @@ import (
 	"github.com/iron-io/runner/drivers"
 )
 
+type taskPriority int
+
+func (t taskPriority) String() string {
+	if t == High {
+		return "High"
+	}
+	return "Low"
+}
+
+const (
+	High taskPriority = iota
+	Low
+)
+
 type TaskRequest struct {
+	Prio     taskPriority
 	Ctx      context.Context
 	Config   *Config
 	Response chan TaskResponse
@@ -18,31 +33,98 @@ type TaskResponse struct {
 	Err    error
 }
 
+// StartWorkers handle incoming tasks and spawns self-regulating container
+// workers. Internally it works with a priority queue, used to favor the
+// execution of Sync tasks over Async ones.
 func StartWorkers(ctx context.Context, rnr *Runner, tasks <-chan TaskRequest) {
 	var wg sync.WaitGroup
+	prioQ := &priotasksqueue{cond: &sync.Cond{L: &sync.Mutex{}}}
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				prioQ.close()
+				return
+			case task := <-tasks:
+				if task.Prio == High {
+					prioQ.pushHigh(task)
+				} else if task.Prio == Low {
+					prioQ.pushLow(task)
+				}
+			}
+		}
+	}()
 
 	wg.Add(1)
 	go func(ctx context.Context) {
 		defer wg.Done()
 		for {
-			select {
-			case <-ctx.Done():
+			task := prioQ.shift()
+			if task == nil {
 				return
-			case task := <-tasks:
-				wg.Add(1)
-				go func(task TaskRequest) {
-					defer wg.Done()
-					result, err := rnr.Run(task.Ctx, task.Config)
-					select {
-					case task.Response <- TaskResponse{result, err}:
-						close(task.Response)
-					default:
-					}
-				}(task)
 			}
+
+			wg.Add(1)
+			go func(task TaskRequest) {
+				defer wg.Done()
+				result, err := rnr.Run(task.Ctx, task.Config)
+				select {
+				case task.Response <- TaskResponse{result, err}:
+					close(task.Response)
+				default:
+				}
+			}(*task)
 		}
 	}(ctx)
 
 	<-ctx.Done()
 	wg.Wait()
+}
+
+type priotasksqueue struct {
+	high, low []TaskRequest
+	cond      *sync.Cond
+	closed    bool
+}
+
+func (p *priotasksqueue) shift() *TaskRequest {
+	p.cond.L.Lock()
+	if len(p.high) == 0 && len(p.low) == 0 && !p.closed {
+		p.cond.Wait()
+	}
+	if p.closed {
+		p.cond.L.Unlock()
+		return nil
+	}
+
+	var v TaskRequest
+	if len(p.high) > 0 {
+		v, p.high = p.high[0], p.high[1:]
+	} else {
+		v, p.low = p.low[0], p.low[1:]
+	}
+	p.cond.L.Unlock()
+	return &v
+}
+
+func (p *priotasksqueue) pushHigh(task TaskRequest) {
+	p.cond.L.Lock()
+	p.high = append(p.high, task)
+	p.cond.L.Unlock()
+	p.cond.Signal()
+}
+
+func (p *priotasksqueue) pushLow(task TaskRequest) {
+	p.cond.L.Lock()
+	p.low = append(p.low, task)
+	p.cond.L.Unlock()
+	p.cond.Signal()
+}
+
+func (p *priotasksqueue) close() {
+	p.cond.L.Lock()
+	p.closed = true
+	p.cond.L.Unlock()
+	p.cond.Signal()
 }

--- a/api/server/routes_test.go
+++ b/api/server/routes_test.go
@@ -13,6 +13,8 @@ import (
 
 func TestRouteCreate(t *testing.T) {
 	buf := setLogBuffer()
+	tasks := mockTasksConduit()
+	defer close(tasks)
 
 	for i, test := range []struct {
 		mock          *datastore.Mock
@@ -33,7 +35,7 @@ func TestRouteCreate(t *testing.T) {
 		// success
 		{&datastore.Mock{}, "/v1/apps/a/routes", `{ "route": { "image": "iron/hello", "path": "/myroute" } }`, http.StatusCreated, nil},
 	} {
-		s := New(test.mock, &mqs.Mock{}, testRunner(t))
+		s := New(test.mock, &mqs.Mock{}, testRunner(t), tasks)
 		router := testRouter(s)
 
 		body := bytes.NewBuffer([]byte(test.body))
@@ -59,7 +61,10 @@ func TestRouteCreate(t *testing.T) {
 
 func TestRouteDelete(t *testing.T) {
 	buf := setLogBuffer()
-	s := New(&datastore.Mock{}, &mqs.Mock{}, testRunner(t))
+	tasks := mockTasksConduit()
+	defer close(tasks)
+
+	s := New(&datastore.Mock{}, &mqs.Mock{}, testRunner(t), tasks)
 	router := testRouter(s)
 
 	for i, test := range []struct {
@@ -93,7 +98,10 @@ func TestRouteDelete(t *testing.T) {
 
 func TestRouteList(t *testing.T) {
 	buf := setLogBuffer()
-	s := New(&datastore.Mock{}, &mqs.Mock{}, testRunner(t))
+	tasks := mockTasksConduit()
+	defer close(tasks)
+
+	s := New(&datastore.Mock{}, &mqs.Mock{}, testRunner(t), tasks)
 	router := testRouter(s)
 
 	for i, test := range []struct {
@@ -126,7 +134,10 @@ func TestRouteList(t *testing.T) {
 
 func TestRouteGet(t *testing.T) {
 	buf := setLogBuffer()
-	s := New(&datastore.Mock{}, &mqs.Mock{}, testRunner(t))
+	tasks := mockTasksConduit()
+	defer close(tasks)
+
+	s := New(&datastore.Mock{}, &mqs.Mock{}, testRunner(t), tasks)
 	router := testRouter(s)
 
 	for i, test := range []struct {
@@ -159,7 +170,10 @@ func TestRouteGet(t *testing.T) {
 
 func TestRouteUpdate(t *testing.T) {
 	buf := setLogBuffer()
-	s := New(&datastore.Mock{}, &mqs.Mock{}, testRunner(t))
+	tasks := mockTasksConduit()
+	defer close(tasks)
+
+	s := New(&datastore.Mock{}, &mqs.Mock{}, testRunner(t), tasks)
 	router := testRouter(s)
 
 	for i, test := range []struct {

--- a/api/server/runner.go
+++ b/api/server/runner.go
@@ -181,10 +181,10 @@ func (s *Server) handleRequest(c *gin.Context, enqueue models.Enqueue) {
 
 	default:
 		tresp := make(chan runner.TaskResponse)
-		treq := runner.TaskRequest{Ctx: c, Config: cfg, Response: tresp}
+		treq := runner.TaskRequest{Prio: runner.High, Ctx: c, Config: cfg, Response: tresp}
 		s.tasks <- treq
-		resp := <-treq.Response
 
+		resp := <-treq.Response
 		result, err := resp.Result, resp.Err
 		if err != nil {
 			break
@@ -198,6 +198,7 @@ func (s *Server) handleRequest(c *gin.Context, enqueue models.Enqueue) {
 		} else {
 			c.AbortWithStatus(http.StatusInternalServerError)
 		}
+
 	}
 }
 

--- a/api/server/runner.go
+++ b/api/server/runner.go
@@ -181,7 +181,7 @@ func (s *Server) handleRequest(c *gin.Context, enqueue models.Enqueue) {
 
 	default:
 		tresp := make(chan runner.TaskResponse)
-		treq := runner.TaskRequest{Prio: runner.High, Ctx: c, Config: cfg, Response: tresp}
+		treq := runner.TaskRequest{Ctx: c, Config: cfg, Response: tresp}
 		s.tasks <- treq
 
 		resp := <-treq.Response

--- a/api/server/runner.go
+++ b/api/server/runner.go
@@ -180,12 +180,8 @@ func (s *Server) handleRequest(c *gin.Context, enqueue models.Enqueue) {
 		log.Info("Added new task to queue")
 
 	default:
-		tresp := make(chan runner.TaskResponse)
-		treq := runner.TaskRequest{Ctx: c, Config: cfg, Response: tresp}
-		s.tasks <- treq
 
-		resp := <-treq.Response
-		result, err := resp.Result, resp.Err
+		result, err := runner.RunTask(s.tasks, ctx, cfg)
 		if err != nil {
 			break
 		}

--- a/api/server/runner.go
+++ b/api/server/runner.go
@@ -15,7 +15,6 @@ import (
 	"github.com/iron-io/functions/api/models"
 	"github.com/iron-io/functions/api/runner"
 	"github.com/iron-io/runner/common"
-	"github.com/iron-io/runner/drivers"
 	uuid "github.com/satori/go.uuid"
 )
 
@@ -35,7 +34,7 @@ func ToEnvName(envtype, name string) string {
 	return fmt.Sprintf("%s_%s", envtype, name)
 }
 
-func handleRequest(c *gin.Context, enqueue models.Enqueue) {
+func (s *Server) handleRequest(c *gin.Context, enqueue models.Enqueue) {
 	if strings.HasPrefix(c.Request.URL.Path, "/v1") {
 		c.Status(http.StatusNotFound)
 		return
@@ -156,7 +155,6 @@ func handleRequest(c *gin.Context, enqueue models.Enqueue) {
 		Stdin:   payload,
 	}
 
-	var result drivers.RunResult
 	switch found.Type {
 	case "async":
 		// Read payload
@@ -182,7 +180,13 @@ func handleRequest(c *gin.Context, enqueue models.Enqueue) {
 		log.Info("Added new task to queue")
 
 	default:
-		if result, err = Api.Runner.Run(c, cfg); err != nil {
+		tresp := make(chan runner.TaskResponse)
+		treq := runner.TaskRequest{Ctx: c, Config: cfg, Response: tresp}
+		s.tasks <- treq
+		resp := <-treq.Response
+
+		result, err := resp.Result, resp.Err
+		if err != nil {
 			break
 		}
 		for k, v := range found.Headers {

--- a/api/server/runner_async_test.go
+++ b/api/server/runner_async_test.go
@@ -31,7 +31,6 @@ func testRouterAsync(s *Server, enqueueFunc models.Enqueue) *gin.Engine {
 func TestRouteRunnerAsyncExecution(t *testing.T) {
 	t.Skip()
 	tasks := mockTasksConduit()
-	defer close(tasks)
 
 	// todo: I broke how this test works trying to clean up the code a bit. Is there a better way to do this test rather than having to override the default route behavior?
 	s := New(&datastore.Mock{

--- a/api/server/runner_async_test.go
+++ b/api/server/runner_async_test.go
@@ -30,6 +30,9 @@ func testRouterAsync(s *Server, enqueueFunc models.Enqueue) *gin.Engine {
 
 func TestRouteRunnerAsyncExecution(t *testing.T) {
 	t.Skip()
+	tasks := mockTasksConduit()
+	defer close(tasks)
+
 	// todo: I broke how this test works trying to clean up the code a bit. Is there a better way to do this test rather than having to override the default route behavior?
 	s := New(&datastore.Mock{
 		FakeApps: []*models.App{
@@ -40,7 +43,7 @@ func TestRouteRunnerAsyncExecution(t *testing.T) {
 			{Type: "async", Path: "/myerror", AppName: "myapp", Image: "iron/error", Config: map[string]string{"test": "true"}},
 			{Type: "async", Path: "/myroute/:param", AppName: "myapp", Image: "iron/hello", Config: map[string]string{"test": "true"}},
 		},
-	}, &mqs.Mock{}, testRunner(t))
+	}, &mqs.Mock{}, testRunner(t), tasks)
 
 	for i, test := range []struct {
 		path         string

--- a/api/server/runner_test.go
+++ b/api/server/runner_test.go
@@ -112,7 +112,7 @@ func TestRouteRunnerExecution(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	go runner.StartWorkers(ctx, 1, testRunner(t), tasks)
+	go runner.StartWorkers(ctx, testRunner(t), tasks)
 
 	s := New(&datastore.Mock{
 		FakeApps: []*models.App{

--- a/api/server/runner_test.go
+++ b/api/server/runner_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	"context"
 	"net/http"
 	"strings"
 	"testing"
@@ -22,11 +23,14 @@ func testRunner(t *testing.T) *runner.Runner {
 
 func TestRouteRunnerGet(t *testing.T) {
 	buf := setLogBuffer()
+	tasks := mockTasksConduit()
+	defer close(tasks)
+
 	s := New(&datastore.Mock{
 		FakeApps: []*models.App{
 			{Name: "myapp", Config: models.Config{}},
 		},
-	}, &mqs.Mock{}, testRunner(t))
+	}, &mqs.Mock{}, testRunner(t), tasks)
 	router := testRouter(s)
 
 	for i, test := range []struct {
@@ -61,11 +65,14 @@ func TestRouteRunnerGet(t *testing.T) {
 
 func TestRouteRunnerPost(t *testing.T) {
 	buf := setLogBuffer()
+	tasks := mockTasksConduit()
+	defer close(tasks)
+
 	s := New(&datastore.Mock{
 		FakeApps: []*models.App{
 			{Name: "myapp", Config: models.Config{}},
 		},
-	}, &mqs.Mock{}, testRunner(t))
+	}, &mqs.Mock{}, testRunner(t), tasks)
 	router := testRouter(s)
 
 	for i, test := range []struct {
@@ -102,6 +109,14 @@ func TestRouteRunnerPost(t *testing.T) {
 
 func TestRouteRunnerExecution(t *testing.T) {
 	buf := setLogBuffer()
+
+	tasks := make(chan runner.TaskRequest)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	defer close(tasks)
+
+	go runner.StartWorkers(ctx, 1, testRunner(t), tasks)
+
 	s := New(&datastore.Mock{
 		FakeApps: []*models.App{
 			{Name: "myapp", Config: models.Config{}},
@@ -110,7 +125,7 @@ func TestRouteRunnerExecution(t *testing.T) {
 			{Path: "/myroute", AppName: "myapp", Image: "iron/hello", Headers: map[string][]string{"X-Function": {"Test"}}},
 			{Path: "/myerror", AppName: "myapp", Image: "iron/error", Headers: map[string][]string{"X-Function": {"Test"}}},
 		},
-	}, &mqs.Mock{}, testRunner(t))
+	}, &mqs.Mock{}, testRunner(t), tasks)
 	router := testRouter(s)
 
 	for i, test := range []struct {

--- a/api/server/runner_test.go
+++ b/api/server/runner_test.go
@@ -24,7 +24,6 @@ func testRunner(t *testing.T) *runner.Runner {
 func TestRouteRunnerGet(t *testing.T) {
 	buf := setLogBuffer()
 	tasks := mockTasksConduit()
-	defer close(tasks)
 
 	s := New(&datastore.Mock{
 		FakeApps: []*models.App{
@@ -66,7 +65,6 @@ func TestRouteRunnerGet(t *testing.T) {
 func TestRouteRunnerPost(t *testing.T) {
 	buf := setLogBuffer()
 	tasks := mockTasksConduit()
-	defer close(tasks)
 
 	s := New(&datastore.Mock{
 		FakeApps: []*models.App{
@@ -113,7 +111,6 @@ func TestRouteRunnerExecution(t *testing.T) {
 	tasks := make(chan runner.TaskRequest)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	defer close(tasks)
 
 	go runner.StartWorkers(ctx, 1, testRunner(t), tasks)
 

--- a/api/server/server_test.go
+++ b/api/server/server_test.go
@@ -91,7 +91,6 @@ func TestFullStack(t *testing.T) {
 	tasks := make(chan runner.TaskRequest)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	defer close(tasks)
 	go runner.StartWorkers(ctx, 1, testRunner(t), tasks)
 
 	s := New(ds, &mqs.Mock{}, testRunner(t), tasks)

--- a/api/server/server_test.go
+++ b/api/server/server_test.go
@@ -91,7 +91,7 @@ func TestFullStack(t *testing.T) {
 	tasks := make(chan runner.TaskRequest)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go runner.StartWorkers(ctx, 1, testRunner(t), tasks)
+	go runner.StartWorkers(ctx, testRunner(t), tasks)
 
 	s := New(ds, &mqs.Mock{}, testRunner(t), tasks)
 	router := testRouter(s)

--- a/api/server/server_test.go
+++ b/api/server/server_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/iron-io/functions/api/datastore"
 	"github.com/iron-io/functions/api/models"
 	"github.com/iron-io/functions/api/mqs"
+	"github.com/iron-io/functions/api/runner"
 	"github.com/iron-io/runner/common"
 )
 
@@ -84,10 +85,16 @@ func prepareBolt(t *testing.T) (models.Datastore, func()) {
 
 func TestFullStack(t *testing.T) {
 	buf := setLogBuffer()
-	ds, close := prepareBolt(t)
-	defer close()
+	ds, closeBolt := prepareBolt(t)
+	defer closeBolt()
 
-	s := New(ds, &mqs.Mock{}, testRunner(t))
+	tasks := make(chan runner.TaskRequest)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	defer close(tasks)
+	go runner.StartWorkers(ctx, 1, testRunner(t), tasks)
+
+	s := New(ds, &mqs.Mock{}, testRunner(t), tasks)
 	router := testRouter(s)
 
 	for i, test := range []struct {
@@ -119,5 +126,4 @@ func TestFullStack(t *testing.T) {
 				i, test.expectedCode, rec.Code)
 		}
 	}
-
 }

--- a/docs/options.md
+++ b/docs/options.md
@@ -31,8 +31,12 @@ docker run -e VAR_NAME=VALUE ...
 <td>Sets the port to run on. Default: `8080`.</td>
 </tr>
 <tr>
-<td>NUM_ASYNC</td>
-<td>The number of async runners in the functions process (default 1).</td>
+<td>ASYNC</td>
+<td>Toggle for async runners in the functions process (default true).</td>
+</tr>
+<tr>
+<td>NUM_RUNNERS</td>
+<td>The number of runners in the functions process (default 30).</td>
 </tr>
 <tr>
 <td>LOG_LEVEL</td>

--- a/docs/options.md
+++ b/docs/options.md
@@ -31,10 +31,6 @@ docker run -e VAR_NAME=VALUE ...
 <td>Sets the port to run on. Default: `8080`.</td>
 </tr>
 <tr>
-<td>ASYNC</td>
-<td>Toggle for async runners in the functions process (default true).</td>
-</tr>
-<tr>
 <td>LOG_LEVEL</td>
 <td>Set to `DEBUG` to enable debugging. Default: INFO.</td>
 </tr>
@@ -47,7 +43,7 @@ a couple reasons why we did it this way:
 
 * It's clean. Once the container exits, there is nothing left behind including all the function images.
 * You can set resource restrictions for the entire IronFunctions instance. For instance, you can set `--memory` on
-the docker run command to set the max memory for the IronFunctions instance AND all of the functions it's running. 
+the docker run command to set the max memory for the IronFunctions instance AND all of the functions it's running.
 
 There are some reasons you may not want to use dind, such as using the image cache during testing or you're running
 [Windows](windows.md).

--- a/docs/options.md
+++ b/docs/options.md
@@ -35,10 +35,6 @@ docker run -e VAR_NAME=VALUE ...
 <td>Toggle for async runners in the functions process (default true).</td>
 </tr>
 <tr>
-<td>NUM_RUNNERS</td>
-<td>The number of runners in the functions process (default 30).</td>
-</tr>
-<tr>
 <td>LOG_LEVEL</td>
 <td>Set to `DEBUG` to enable debugging. Default: INFO.</td>
 </tr>

--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ const (
 	envPort       = "port" // be careful, Gin expects this variable to be "port"
 	envAPIURL     = "api_url"
 	envAsync      = "async"
-	envNumWorkers = "num_workers"
+	envNumRunners = "num_runners"
 )
 
 func init() {
@@ -39,7 +39,7 @@ func init() {
 	viper.SetDefault(envPort, 8080)
 	viper.SetDefault(envAPIURL, fmt.Sprintf("http://127.0.0.1:%d", viper.GetInt(envPort)))
 	viper.SetDefault(envAsync, 1)
-	viper.SetDefault(envNumWorkers, 30)
+	viper.SetDefault(envNumRunners, 30)
 	viper.AutomaticEnv() // picks up env vars automatically
 	logLevel, err := log.ParseLevel(viper.GetString("log_level"))
 	if err != nil {
@@ -86,9 +86,9 @@ func main() {
 
 	tasks := make(chan runner.TaskRequest)
 
-	numWorkers := viper.GetInt(envNumWorkers)
+	numRunners := viper.GetInt(envNumRunners)
 	svr.AddFunc(func(ctx context.Context) {
-		runner.StartWorkers(ctx, numWorkers, rnr, tasks)
+		runner.StartWorkers(ctx, numRunners, rnr, tasks)
 	})
 
 	svr.AddFunc(func(ctx context.Context) {

--- a/main.go
+++ b/main.go
@@ -18,13 +18,12 @@ import (
 )
 
 const (
-	envLogLevel   = "log_level"
-	envMQ         = "mq_url"
-	envDB         = "db_url"
-	envPort       = "port" // be careful, Gin expects this variable to be "port"
-	envAPIURL     = "api_url"
-	envAsync      = "async"
-	envNumRunners = "num_runners"
+	envLogLevel = "log_level"
+	envMQ       = "mq_url"
+	envDB       = "db_url"
+	envPort     = "port" // be careful, Gin expects this variable to be "port"
+	envAPIURL   = "api_url"
+	envAsync    = "async"
 )
 
 func init() {
@@ -39,7 +38,6 @@ func init() {
 	viper.SetDefault(envPort, 8080)
 	viper.SetDefault(envAPIURL, fmt.Sprintf("http://127.0.0.1:%d", viper.GetInt(envPort)))
 	viper.SetDefault(envAsync, 1)
-	viper.SetDefault(envNumRunners, 30)
 	viper.AutomaticEnv() // picks up env vars automatically
 	logLevel, err := log.ParseLevel(viper.GetString("log_level"))
 	if err != nil {
@@ -86,9 +84,8 @@ func main() {
 
 	tasks := make(chan runner.TaskRequest)
 
-	numRunners := viper.GetInt(envNumRunners)
 	svr.AddFunc(func(ctx context.Context) {
-		runner.StartWorkers(ctx, numRunners, rnr, tasks)
+		runner.StartWorkers(ctx, rnr, tasks)
 	})
 
 	svr.AddFunc(func(ctx context.Context) {

--- a/main.go
+++ b/main.go
@@ -23,7 +23,6 @@ const (
 	envDB       = "db_url"
 	envPort     = "port" // be careful, Gin expects this variable to be "port"
 	envAPIURL   = "api_url"
-	envAsync    = "async"
 )
 
 func init() {
@@ -37,7 +36,6 @@ func init() {
 	viper.SetDefault(envDB, fmt.Sprintf("bolt://%s/data/bolt.db?bucket=funcs", cwd))
 	viper.SetDefault(envPort, 8080)
 	viper.SetDefault(envAPIURL, fmt.Sprintf("http://127.0.0.1:%d", viper.GetInt(envPort)))
-	viper.SetDefault(envAsync, 1)
 	viper.AutomaticEnv() // picks up env vars automatically
 	logLevel, err := log.ParseLevel(viper.GetString("log_level"))
 	if err != nil {
@@ -93,13 +91,10 @@ func main() {
 		srv.Run(ctx)
 	})
 
-	apiURL, async := viper.GetString(envAPIURL), viper.GetBool(envAsync)
-	log.Debug("async workers:", async)
-	if async {
-		svr.AddFunc(func(ctx context.Context) {
-			runner.RunAsyncRunner(ctx, apiURL, tasks)
-		})
-	}
+	apiURL := viper.GetString(envAPIURL)
+	svr.AddFunc(func(ctx context.Context) {
+		runner.RunAsyncRunner(ctx, apiURL, tasks)
+	})
 
 	svr.Serve(ctx)
 	close(tasks)

--- a/main.go
+++ b/main.go
@@ -93,7 +93,7 @@ func main() {
 
 	apiURL := viper.GetString(envAPIURL)
 	svr.AddFunc(func(ctx context.Context) {
-		runner.RunAsyncRunner(ctx, apiURL, tasks)
+		runner.RunAsyncRunner(ctx, apiURL, tasks, rnr)
 	})
 
 	svr.Serve(ctx)


### PR DESCRIPTION
This is a proposal that addresses concerns some aspects of https://github.com/iron-io/functions/issues/165  and https://github.com/iron-io/functions/issues/69.

1 - We have now a supervised goroutine that spawns workers for the incoming load. They serve any kind of request, sync or async (#165)

2 - Because runners start are separate from request life-cycle, we would be a third way closer to have hot reusable containers (#69)

Edit: 
***Implementation Details***

This PR introduces new goroutine responsible solely for executing tasks. It interfaces with the HTTP server and async modules through a channel, whose contents holds both the task information, and a channel to send the answer backer to the caller. https://github.com/iron-io/functions/blob/bounded-concurrency/api/server/runner.go#L183-L188 and https://github.com/iron-io/functions/blob/bounded-concurrency/api/runner/async_runner.go#L142-L145

In order to prevent resource starvation between competing sync and async tasks, we reserve a maxium of 50% of the memory for async tasks. This number is arbitrary and might be subject to changes later. https://github.com/iron-io/functions/blob/bounded-concurrency/api/runner/runner.go#L118-L123

In practice, when the memory allocated for async workers is maxed out, it keeps looping until memory is available: https://github.com/iron-io/functions/blob/bounded-concurrency/api/runner/async_runner.go#L117-L121

Also relevant is that `Server` now fathers handleRequest https://github.com/iron-io/functions/blob/bounded-concurrency/api/server/runner.go#L37 - with which it injects the tasks channel into the HTTP server.

