### PR TITLE
[WIP] Refactoring API error responses / fix swagger

### DIFF
--- a/api/datastore/bolt_test.go
+++ b/api/datastore/bolt_test.go
@@ -119,16 +119,22 @@ func TestBolt(t *testing.T) {
 	err = ds.RemoveApp(testApp.Name)
 	if err != nil {
 		t.Log(buf.String())
-		t.Fatalf("Test RemoveApp: error: %s", err)
+		t.Fatalf("Test RemoveApp: unexpected error: %s", err)
 	}
 	app, err = ds.GetApp(testApp.Name)
 	if err != nil {
 		t.Log(buf.String())
-		t.Fatalf("Test GetApp: error: %s", err)
+		t.Fatalf("Test GetApp: unexpected error: %s", err)
 	}
 	if app != nil {
 		t.Log(buf.String())
 		t.Fatalf("Test RemoveApp: failed to remove the app")
+	}
+
+	err = ds.RemoveApp(testRoute.AppName)
+	if err != models.ErrAppsNotFound {
+		t.Log(buf.String())
+		t.Fatalf("Test RemoveApp: expected error `%v`, but it was `%s`", models.ErrAppsNotFound, err)
 	}
 
 	// Test update inexistent app
@@ -238,7 +244,13 @@ func TestBolt(t *testing.T) {
 	err = ds.RemoveRoute(testRoute.AppName, testRoute.Path)
 	if err != nil {
 		t.Log(buf.String())
-		t.Fatalf("Test RemoveApp: unexpected error: %v", err)
+		t.Fatalf("Test RemoveRoute: unexpected error: %v", err)
+	}
+
+	err = ds.RemoveRoute(testRoute.AppName, testRoute.Path)
+	if err != models.ErrRoutesNotFound {
+		t.Log(buf.String())
+		t.Fatalf("Test RemoveRoute: expected error `%v`, but it was `%s`", models.ErrRoutesNotFound, err)
 	}
 
 	_, err = ds.UpdateRoute(&models.Route{
@@ -258,6 +270,6 @@ func TestBolt(t *testing.T) {
 	}
 	if route != nil {
 		t.Log(buf.String())
-		t.Fatalf("Test RemoveApp: failed to remove the route")
+		t.Fatalf("Test RemoveRoute: failed to remove the route")
 	}
 }

--- a/api/datastore/mock.go
+++ b/api/datastore/mock.go
@@ -38,8 +38,13 @@ func (m *Mock) UpdateApp(app *models.App) (*models.App, error) {
 }
 
 func (m *Mock) RemoveApp(appName string) error {
-	// TODO: improve this mock method
-	return nil
+	for _, a := range m.FakeApps {
+		if a.Name == appName {
+			// TODO: implement real app remove
+			return nil
+		}
+	}
+	return models.ErrAppsNotFound
 }
 
 func (m *Mock) GetRoute(appName, routePath string) (*models.Route, error) {
@@ -85,8 +90,13 @@ func (m *Mock) UpdateRoute(route *models.Route) (*models.Route, error) {
 }
 
 func (m *Mock) RemoveRoute(appName, routePath string) error {
-	// TODO: improve this mock method
-	return nil
+	for _, r := range m.FakeRoutes {
+		if r.AppName == appName && r.Path == routePath {
+			// TODO: implement real route remove
+			return nil
+		}
+	}
+	return models.ErrRoutesNotFound
 }
 
 func (m *Mock) Put(key, value []byte) error {

--- a/api/datastore/postgres/postgres.go
+++ b/api/datastore/postgres/postgres.go
@@ -152,13 +152,22 @@ func (ds *PostgresDatastore) RemoveApp(appName string) error {
 		return models.ErrDatastoreEmptyAppName
 	}
 
-	_, err := ds.db.Exec(`
+	res, err := ds.db.Exec(`
 	  DELETE FROM apps
 	  WHERE name = $1
 	`, appName)
 
 	if err != nil {
 		return err
+	}
+
+	n, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+
+	if n == 0 {
+		return models.ErrAppsNotFound
 	}
 
 	return nil
@@ -352,7 +361,7 @@ func (ds *PostgresDatastore) RemoveRoute(appName, routePath string) error {
 	}
 
 	if n == 0 {
-		return models.ErrRoutesRemoving
+		return models.ErrRoutesNotFound
 	}
 
 	return nil

--- a/api/datastore/postgres_test.go
+++ b/api/datastore/postgres_test.go
@@ -72,7 +72,7 @@ func TestPostgres(t *testing.T) {
 	_, err = ds.InsertApp(testApp)
 	if err != nil {
 		t.Log(buf.String())
-		t.Fatalf("Test InsertApp: error when storing new app: %s", err)
+		t.Fatalf("Test InsertApp: unexpected error: %v", err)
 	}
 
 	_, err = ds.InsertApp(testApp)
@@ -96,24 +96,24 @@ func TestPostgres(t *testing.T) {
 	_, err = ds.GetApp("")
 	if err != models.ErrDatastoreEmptyAppName {
 		t.Log(buf.String())
-		t.Fatalf("Test GetApp: expected error to be %v, but it was %s", models.ErrDatastoreEmptyAppName, err)
+		t.Fatalf("Test GetApp: expected error to be `%v`, but it was `%v`", models.ErrDatastoreEmptyAppName, err)
 	}
 
 	app, err := ds.GetApp(testApp.Name)
 	if err != nil {
 		t.Log(buf.String())
-		t.Fatalf("Test GetApp: error: %s", err)
+		t.Fatalf("Test GetApp: unexpected error: %v", err)
 	}
 	if app.Name != testApp.Name {
 		t.Log(buf.String())
-		t.Fatalf("Test GetApp: expected `app.Name` to be `%s` but it was `%s`", app.Name, testApp.Name)
+		t.Fatalf("Test GetApp: expected app name to be `%s`, but it was `%s`", app.Name, testApp.Name)
 	}
 
 	// Testing list apps
 	apps, err := ds.GetApps(&models.AppFilter{})
 	if err != nil {
 		t.Log(buf.String())
-		t.Fatalf("Test GetApps: unexpected error %v", err)
+		t.Fatalf("Test GetApps: unexpected error: %v", err)
 	}
 	if len(apps) == 0 {
 		t.Fatal("Test GetApps: expected result count to be greater than 0")
@@ -133,7 +133,7 @@ func TestPostgres(t *testing.T) {
 	err = ds.RemoveApp(testApp.Name)
 	if err != nil {
 		t.Log(buf.String())
-		t.Fatalf("Test RemoveApp: error: %s", err)
+		t.Fatalf("Test RemoveApp: unexpected error: %v", err)
 	}
 	app, err = ds.GetApp(testApp.Name)
 	if err != models.ErrAppsNotFound {
@@ -143,6 +143,12 @@ func TestPostgres(t *testing.T) {
 	if app != nil {
 		t.Log(buf.String())
 		t.Fatalf("Test RemoveApp: failed to remove the app")
+	}
+
+	err = ds.RemoveApp(testApp.Name)
+	if err != models.ErrAppsNotFound {
+		t.Log(buf.String())
+		t.Fatalf("Test RemoveApp: expected error `%v`, but it was `%v`", models.ErrAppsNotFound, err)
 	}
 
 	// Test update inexistent app
@@ -170,7 +176,7 @@ func TestPostgres(t *testing.T) {
 	_, err = ds.InsertRoute(testRoute)
 	if err != nil {
 		t.Log(buf.String())
-		t.Fatalf("Test InsertRoute: error when storing new route: %s", err)
+		t.Fatalf("Test InsertRoute: unexpected error: %v", err)
 	}
 
 	_, err = ds.InsertRoute(testRoute)
@@ -205,7 +211,7 @@ func TestPostgres(t *testing.T) {
 	}
 	if route.Path != testRoute.Path {
 		t.Log(buf.String())
-		t.Fatalf("Test GetRoute: expected `route.Path` to be `%s` but it was `%s`", route.Path, testRoute.Path)
+		t.Fatalf("Test GetRoute: expected route.Path to be `%v`, but it was `%v`", route.Path, testRoute.Path)
 	}
 
 	// Testing list routes
@@ -219,21 +225,21 @@ func TestPostgres(t *testing.T) {
 	}
 	if routes[0].Path != testRoute.Path {
 		t.Log(buf.String())
-		t.Fatalf("Test GetRoutes: expected `app.Name` to be `%s` but it was `%s`", testRoute.Path, routes[0].Path)
+		t.Fatalf("Test GetRoutes: expected app.Name to be `%v` but it was `%v`", testRoute.Path, routes[0].Path)
 	}
 
 	// Testing list routes
 	routes, err = ds.GetRoutes(&models.RouteFilter{Image: testRoute.Image})
 	if err != nil {
 		t.Log(buf.String())
-		t.Fatalf("Test GetRoutes: error: %s", err)
+		t.Fatalf("Test GetRoutes: unexpected error: %v", err)
 	}
 	if len(routes) == 0 {
 		t.Fatal("Test GetRoutes: expected result count to be greater than 0")
 	}
 	if routes[0].Path != testRoute.Path {
 		t.Log(buf.String())
-		t.Fatalf("Test GetRoutes: expected `app.Name` to be `%s` but it was `%s`", testRoute.Path, routes[0].Path)
+		t.Fatalf("Test GetRoutes: expected app.Name to be `%v` but it was `%v`", testRoute.Path, routes[0].Path)
 	}
 
 	// Testing app delete
@@ -252,7 +258,13 @@ func TestPostgres(t *testing.T) {
 	err = ds.RemoveRoute(testRoute.AppName, testRoute.Path)
 	if err != nil {
 		t.Log(buf.String())
-		t.Fatalf("Test RemoveApp: unexpected error: %v", err)
+		t.Fatalf("Test RemoveRoute: unexpected error: %v", err)
+	}
+
+	err = ds.RemoveRoute(testRoute.AppName, testRoute.Path)
+	if err != models.ErrRoutesNotFound {
+		t.Log(buf.String())
+		t.Fatalf("Test RemoveRoute: expected error `%v`, but it was `%v`", models.ErrRoutesNotFound, err)
 	}
 
 	_, err = ds.UpdateRoute(&models.Route{
@@ -272,6 +284,6 @@ func TestPostgres(t *testing.T) {
 	}
 	if route != nil {
 		t.Log(buf.String())
-		t.Fatalf("Test RemoveApp: failed to remove the route")
+		t.Fatalf("Test RemoveRoute: failed to remove the route")
 	}
 }

--- a/api/models/app.go
+++ b/api/models/app.go
@@ -10,7 +10,6 @@ type Apps []*App
 var (
 	ErrAppsCreate          = errors.New("Could not create app")
 	ErrAppsUpdate          = errors.New("Could not update app")
-	ErrAppsRemoving        = errors.New("Could not remove app from datastore")
 	ErrAppsGet             = errors.New("Could not get app from datastore")
 	ErrAppsList            = errors.New("Could not list apps from datastore")
 	ErrAppsAlreadyExists   = errors.New("App already exists")

--- a/api/models/route.go
+++ b/api/models/route.go
@@ -13,7 +13,6 @@ import (
 var (
 	ErrRoutesCreate        = errors.New("Could not create route")
 	ErrRoutesUpdate        = errors.New("Could not update route")
-	ErrRoutesRemoving      = errors.New("Could not remove route from datastore")
 	ErrRoutesGet           = errors.New("Could not get route from datastore")
 	ErrRoutesList          = errors.New("Could not list routes from datastore")
 	ErrRoutesAlreadyExists = errors.New("Route already exists")

--- a/api/server/apps_delete.go
+++ b/api/server/apps_delete.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"github.com/iron-io/functions/api/models"
 	"github.com/iron-io/runner/common"
 )
 
@@ -14,11 +13,11 @@ func handleAppDelete(c *gin.Context) {
 	log := common.Logger(ctx)
 
 	appName := c.Param("app")
-	err := Api.Datastore.RemoveApp(appName)
 
+	err := Api.Datastore.RemoveApp(appName)
 	if err != nil {
-		log.WithError(err).Debug(models.ErrAppsRemoving)
-		c.JSON(http.StatusInternalServerError, simpleError(models.ErrAppsRemoving))
+		log.Error(err)
+		c.JSON(http.StatusInternalServerError, simpleError(err))
 		return
 	}
 

--- a/api/server/routes_delete.go
+++ b/api/server/routes_delete.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"github.com/iron-io/functions/api/models"
 	"github.com/iron-io/runner/common"
 )
 
@@ -15,11 +14,11 @@ func handleRouteDelete(c *gin.Context) {
 
 	appName := c.Param("app")
 	routePath := c.Param("route")
-	err := Api.Datastore.RemoveRoute(appName, routePath)
 
+	err := Api.Datastore.RemoveRoute(appName, routePath)
 	if err != nil {
-		log.WithError(err).Debug(models.ErrRoutesRemoving)
-		c.JSON(http.StatusInternalServerError, simpleError(models.ErrRoutesRemoving))
+		log.Error(err)
+		c.JSON(http.StatusInternalServerError, simpleError(err))
 		return
 	}
 

--- a/docs/swagger.yml
+++ b/docs/swagger.yml
@@ -125,6 +125,30 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
+    delete:
+      summary: "Delete an app"
+      description: "Remove an empty app (no routes) from the API"
+      tags:
+        - Apps
+      parameters:
+        - name: app
+          in: path 
+          description: name of the app.
+          required: true
+          type: string
+      responses:
+        200:
+          description: App details and stats.
+          schema:
+            $ref: '#/definitions/AppWrapper'
+        404:
+          description: App does not exist.
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
 
   /apps/{app}/routes:
     post:
@@ -233,6 +257,14 @@ paths:
       responses:
         200:
           description: Route successfully deleted. Deletion succeeds even on routes that do not exist.
+        404:
+          description: Route does not exist.
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
 
   /tasks:
     get:


### PR DESCRIPTION
The objective of this PR:
- Try to standardize all API error responses in order to get better error messages to clients (like fnctl).
- Keep almost all error handling, and correctly send those errors in the API response with their correct status codes.
- Improve tests coverage and make tests more consistent.