### PR TITLE
Fix datastore Put and added tests

### DIFF
--- a/api/datastore/bolt/bolt.go
+++ b/api/datastore/bolt/bolt.go
@@ -505,6 +505,10 @@ func (ds *BoltDatastore) GetRoutes(ctx context.Context, filter *models.RouteFilt
 }
 
 func (ds *BoltDatastore) Put(ctx context.Context, key, value []byte) error {
+	if key == nil || len(key) == 0 {
+		return models.ErrDatastoreEmptyKey
+	}
+
 	ds.db.Update(func(tx *bolt.Tx) error {
 		b := tx.Bucket(ds.extrasBucket) // todo: maybe namespace by app?
 		err := b.Put(key, value)
@@ -514,6 +518,10 @@ func (ds *BoltDatastore) Put(ctx context.Context, key, value []byte) error {
 }
 
 func (ds *BoltDatastore) Get(ctx context.Context, key []byte) ([]byte, error) {
+	if key == nil || len(key) == 0 {
+		return nil, models.ErrDatastoreEmptyKey
+	}
+
 	var ret []byte
 	ds.db.View(func(tx *bolt.Tx) error {
 		b := tx.Bucket(ds.extrasBucket)

--- a/api/datastore/datastore_test.go
+++ b/api/datastore/datastore_test.go
@@ -1,0 +1,31 @@
+package datastore
+
+import (
+	"bytes"
+	"github.com/Sirupsen/logrus"
+	"github.com/gin-gonic/gin"
+	"github.com/iron-io/functions/api/models"
+	"log"
+)
+
+func setLogBuffer() *bytes.Buffer {
+	var buf bytes.Buffer
+	buf.WriteByte('\n')
+	logrus.SetOutput(&buf)
+	gin.DefaultErrorWriter = &buf
+	gin.DefaultWriter = &buf
+	log.SetOutput(&buf)
+	return &buf
+}
+
+var testApp = &models.App{
+	Name: "Test",
+}
+
+var testRoute = &models.Route{
+	AppName: testApp.Name,
+	Path:    "/test",
+	Image:   "iron/hello",
+	Type:    "sync",
+	Format:  "http",
+}

--- a/api/datastore/postgres/postgres.go
+++ b/api/datastore/postgres/postgres.go
@@ -524,6 +524,10 @@ func buildFilterRouteQuery(filter *models.RouteFilter) string {
 }
 
 func (ds *PostgresDatastore) Put(ctx context.Context, key, value []byte) error {
+	if key == nil || len(key) == 0 {
+		return models.ErrDatastoreEmptyKey
+	}
+
 	_, err := ds.db.Exec(`
 	    INSERT INTO extras (
 			key,
@@ -531,7 +535,7 @@ func (ds *PostgresDatastore) Put(ctx context.Context, key, value []byte) error {
 		)
 		VALUES ($1, $2)
 		ON CONFLICT (key) DO UPDATE SET
-			value = $1;
+			value = $2;
 		`, string(key), string(value))
 
 	if err != nil {
@@ -542,6 +546,10 @@ func (ds *PostgresDatastore) Put(ctx context.Context, key, value []byte) error {
 }
 
 func (ds *PostgresDatastore) Get(ctx context.Context, key []byte) ([]byte, error) {
+	if key == nil || len(key) == 0 {
+		return nil, models.ErrDatastoreEmptyKey
+	}
+
 	row := ds.db.QueryRow("SELECT value FROM extras WHERE key=$1", key)
 
 	var value string

--- a/api/datastore/postgres_test.go
+++ b/api/datastore/postgres_test.go
@@ -49,18 +49,6 @@ func TestPostgres(t *testing.T) {
 		t.Fatalf("Error when creating datastore: %v", err)
 	}
 
-	testApp := &models.App{
-		Name: "Test",
-	}
-
-	testRoute := &models.Route{
-		AppName: testApp.Name,
-		Path:    "/test",
-		Image:   "iron/hello",
-		Type:    "sync",
-		Format:  "http",
-	}
-
 	// Testing insert app
 	_, err = ds.InsertApp(ctx, nil)
 	if err != models.ErrDatastoreEmptyApp {
@@ -288,4 +276,48 @@ func TestPostgres(t *testing.T) {
 		t.Log(buf.String())
 		t.Fatalf("Test RemoveApp: failed to remove the route")
 	}
+
+	// Testing Put/Get
+	err = ds.Put(ctx, nil, nil)
+	if err != models.ErrDatastoreEmptyKey {
+		t.Log(buf.String())
+		t.Fatalf("Test Put(nil,nil): expected error `%v`, but it was `%v`", models.ErrDatastoreEmptyKey, err)
+	}
+
+	err = ds.Put(ctx, []byte("test"), []byte("success"))
+	if err != nil {
+		t.Log(buf.String())
+		t.Fatalf("Test Put: unexpected error: %v", err)
+	}
+
+	val, err := ds.Get(ctx, []byte("test"))
+	if err != nil {
+		t.Log(buf.String())
+		t.Fatalf("Test Put: unexpected error: %v", err)
+	}
+	if string(val) != "success" {
+		t.Log(buf.String())
+		t.Fatalf("Test Get: expected value to be `%v`, but it was `%v`", "success", string(val))
+	}
+
+	err = ds.Put(ctx, []byte("test"), nil)
+	if err != nil {
+		t.Log(buf.String())
+		t.Fatalf("Test Put: unexpected error: %v", err)
+	}
+
+	val, err = ds.Get(ctx, []byte("test"))
+	if err != nil {
+		t.Log(buf.String())
+		t.Fatalf("Test Put: unexpected error: %v", err)
+	}
+	if string(val) != "" {
+		t.Log(buf.String())
+		t.Fatalf("Test Get: expected value to be `%v`, but it was `%v`", "", string(val))
+	}
+
+}
+
+func testPostgresInsert(t *testing.T, ctx context.Context, ds models.Datastore) {
+
 }

--- a/api/models/datastore.go
+++ b/api/models/datastore.go
@@ -30,4 +30,5 @@ var (
 	ErrDatastoreEmptyRoutePath = errors.New("Missing route name")
 	ErrDatastoreEmptyApp       = errors.New("Missing app")
 	ErrDatastoreEmptyRoute     = errors.New("Missing route")
+	ErrDatastoreEmptyKey       = errors.New("Missing key")
 )


### PR DESCRIPTION
The postgres Put method was saving the key as value during updates.
Also added an error if the key is empty.
And added some tests to expect the correct behavior.