### PR TITLE
Disable envAsHeader by default

### DIFF
--- a/fn/routes.go
+++ b/fn/routes.go
@@ -237,7 +237,9 @@ func callfn(u string, content io.Reader, output io.Writer, env []string) error {
 
 	req.Header.Set("Content-Type", "application/json")
 
-	envAsHeader(req, env)
+	if len(env) > 0 {
+		envAsHeader(req, env)
+	}
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/fn/run.go
+++ b/fn/run.go
@@ -29,7 +29,7 @@ func runflags() []cli.Flag {
 	return []cli.Flag{
 		cli.StringSliceFlag{
 			Name:  "e",
-			Usage: "select environment variables to be sent to function, if ommited then all are sent.",
+			Usage: "select environment variables to be sent to function",
 		},
 	}
 }

--- a/fn/run.go
+++ b/fn/run.go
@@ -29,7 +29,7 @@ func runflags() []cli.Flag {
 	return []cli.Flag{
 		cli.StringSliceFlag{
 			Name:  "e",
-			Usage: "limit the environment variables sent to function, if ommited then all are sent.",
+			Usage: "select environment variables to be sent to function, if ommited then all are sent.",
 		},
 	}
 }


### PR DESCRIPTION
## Motive
Some enviroments (for example like mine) has some env values that causes some unexpected behaviors in the `fn call`. Users with the same kind of env might have problems running examples.

## Solution
Only call envAsHeader if the -e flag has at least one selected env variable.