### PR TITLE
Overwrite config/headers on update using boltdb

### DIFF
--- a/api/datastore/bolt/bolt.go
+++ b/api/datastore/bolt/bolt.go
@@ -143,12 +143,7 @@ func (ds *BoltDatastore) UpdateApp(ctx context.Context, newapp *models.App) (*mo
 
 		// Update app fields
 		if newapp.Config != nil {
-			if app.Config == nil {
-				app.Config = map[string]string{}
-			}
-			for k, v := range newapp.Config {
-				app.Config[k] = v
-			}
+			app.Config = newapp.Config
 		}
 
 		buf, err := json.Marshal(app)
@@ -352,20 +347,10 @@ func (ds *BoltDatastore) UpdateRoute(ctx context.Context, newroute *models.Route
 			route.MaxConcurrency = newroute.MaxConcurrency
 		}
 		if newroute.Headers != nil {
-			if route.Headers == nil {
-				route.Headers = map[string][]string{}
-			}
-			for k, v := range newroute.Headers {
-				route.Headers[k] = v
-			}
+			route.Headers = newroute.Headers
 		}
 		if newroute.Config != nil {
-			if route.Config == nil {
-				route.Config = map[string]string{}
-			}
-			for k, v := range newroute.Config {
-				route.Config[k] = v
-			}
+			route.Config = newroute.Config
 		}
 
 		if err := route.Validate(); err != nil {


### PR DESCRIPTION
Postgres is overwriting it right now.

Fixes #453 (To delete single keys the client will have to handle it, that's what is happening right now in `fn`)