### PR TITLE
API initialization changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Bugfixes
 
+- [#483](https://github.com/iron-io/functions/pull/483): Listen for PORT before running async/sync workers in order to prevent errors.
 - [#429](https://github.com/iron-io/functions/issues/429): Broken docs after merge.
 - [#422](https://github.com/iron-io/functions/issues/422): The headers field in func.yaml expects an array of values for each header key.
 - [#421](https://github.com/iron-io/functions/issues/421): Can't update a route and show better error message.

--- a/api/datastore/bolt/bolt.go
+++ b/api/datastore/bolt/bolt.go
@@ -34,7 +34,7 @@ func New(url *url.URL) (models.Datastore, error) {
 		log.WithError(err).Errorln("Could not create data directory for db")
 		return nil, err
 	}
-	log.Infoln("Creating bolt db at ", url.Path)
+	log.WithFields(logrus.Fields{"path": url.Path}).Debug("Creating bolt db")
 	db, err := bolt.Open(url.Path, 0655, &bolt.Options{Timeout: 1 * time.Second})
 	if err != nil {
 		log.WithError(err).Errorln("Error on bolt.Open")
@@ -72,7 +72,7 @@ func New(url *url.URL) (models.Datastore, error) {
 		db:           db,
 		log:          log,
 	}
-	log.WithFields(logrus.Fields{"prefix": bucketPrefix, "file": url.Path}).Info("BoltDB initialized")
+	log.WithFields(logrus.Fields{"prefix": bucketPrefix, "file": url.Path}).Debug("BoltDB initialized")
 
 	return ds, nil
 }

--- a/api/mqs/bolt.go
+++ b/api/mqs/bolt.go
@@ -97,7 +97,7 @@ func NewBoltMQ(url *url.URL) (*BoltDbMQ, error) {
 		db:     db,
 	}
 	mq.Start()
-	log.WithFields(logrus.Fields{"file": url.Path}).Info("BoltDb initialized")
+	log.WithFields(logrus.Fields{"file": url.Path}).Debug("BoltDb initialized")
 	return mq, nil
 }
 

--- a/api/runner/async_runner.go
+++ b/api/runner/async_runner.go
@@ -85,7 +85,9 @@ func deleteTask(url string, task *models.Task) error {
 // RunAsyncRunner pulls tasks off a queue and processes them
 func RunAsyncRunner(ctx context.Context, tasksrv string, tasks chan task.Request, rnr *Runner) {
 	u := tasksrvURL(tasksrv)
+
 	startAsyncRunners(ctx, u, tasks, rnr)
+	<-ctx.Done()
 }
 
 func startAsyncRunners(ctx context.Context, url string, tasks chan task.Request, rnr *Runner) {

--- a/api/runner/async_runner.go
+++ b/api/runner/async_runner.go
@@ -85,9 +85,7 @@ func deleteTask(url string, task *models.Task) error {
 // RunAsyncRunner pulls tasks off a queue and processes them
 func RunAsyncRunner(ctx context.Context, tasksrv string, tasks chan task.Request, rnr *Runner) {
 	u := tasksrvURL(tasksrv)
-
 	startAsyncRunners(ctx, u, tasks, rnr)
-	<-ctx.Done()
 }
 
 func startAsyncRunners(ctx context.Context, url string, tasks chan task.Request, rnr *Runner) {

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -197,17 +197,17 @@ func (s *Server) startGears(ctx context.Context) {
 	}
 
 	svr.AddFunc(func(ctx context.Context) {
-		go http.Serve(listener, s.Router)
+		http.Serve(listener, s.Router)
 		<-ctx.Done()
 	})
 
 	svr.AddFunc(func(ctx context.Context) {
-		go runner.RunAsyncRunner(ctx, s.apiURL, s.tasks, s.Runner)
+		runner.RunAsyncRunner(ctx, s.apiURL, s.tasks, s.Runner)
 		<-ctx.Done()
 	})
 
 	svr.AddFunc(func(ctx context.Context) {
-		go runner.StartWorkers(ctx, s.Runner, s.tasks)
+		runner.StartWorkers(ctx, s.Runner, s.tasks)
 		<-ctx.Done()
 	})
 

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"path"
 	"sync"
 
-	"fmt"
 	"github.com/Sirupsen/logrus"
 	"github.com/ccirello/supervisor"
 	"github.com/gin-gonic/gin"
@@ -20,7 +21,6 @@ import (
 	"github.com/iron-io/functions/api/server/internal/routecache"
 	"github.com/iron-io/runner/common"
 	"github.com/spf13/viper"
-	"net"
 )
 
 const (
@@ -180,6 +180,15 @@ func (s *Server) Start(ctx context.Context) {
 }
 
 func (s *Server) startGears(ctx context.Context) {
+	// By default it serves on :8080 unless a
+	// PORT environment variable was defined.
+	listen := fmt.Sprintf(":%d", viper.GetInt(EnvPort))
+	listener, err := net.Listen("tcp", listen)
+	if err != nil {
+		logrus.WithError(err).Fatalln("Failed to serve functions API.")
+	}
+	logrus.Infof("Serving Functions API on address `%s`", listen)
+
 	svr := &supervisor.Supervisor{
 		MaxRestarts: supervisor.AlwaysRestart,
 		Log: func(msg interface{}) {
@@ -187,18 +196,18 @@ func (s *Server) startGears(ctx context.Context) {
 		},
 	}
 
-	// By default it serves on :8080 unless a
-	// PORT environment variable was defined.
 	svr.AddFunc(func(ctx context.Context) {
-		listen := fmt.Sprintf(":%d", viper.GetInt(EnvPort))
-		listener, err := net.Listen("tcp", listen)
-		if err != nil {
-			logrus.WithError(err).Fatalln("Failed to serve functions API.")
-		}
-		logrus.Infof("Serving Functions API on address `%s`", listen)
-		go runner.StartWorkers(ctx, s.Runner, s.tasks)
-		go runner.RunAsyncRunner(ctx, s.apiURL, s.tasks, s.Runner)
 		go http.Serve(listener, s.Router)
+		<-ctx.Done()
+	})
+
+	svr.AddFunc(func(ctx context.Context) {
+		go runner.RunAsyncRunner(ctx, s.apiURL, s.tasks, s.Runner)
+		<-ctx.Done()
+	})
+
+	svr.AddFunc(func(ctx context.Context) {
+		go runner.StartWorkers(ctx, s.Runner, s.tasks)
 		<-ctx.Done()
 	})
 

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -197,7 +197,12 @@ func (s *Server) startGears(ctx context.Context) {
 	}
 
 	svr.AddFunc(func(ctx context.Context) {
-		http.Serve(listener, s.Router)
+		go func() {
+			err := http.Serve(listener, s.Router)
+			if err != nil {
+				logrus.Fatalf("Error serving API: %v", err)
+			}
+		}()
 		<-ctx.Done()
 	})
 

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -203,12 +203,10 @@ func (s *Server) startGears(ctx context.Context) {
 
 	svr.AddFunc(func(ctx context.Context) {
 		runner.RunAsyncRunner(ctx, s.apiURL, s.tasks, s.Runner)
-		<-ctx.Done()
 	})
 
 	svr.AddFunc(func(ctx context.Context) {
 		runner.StartWorkers(ctx, s.Runner, s.tasks)
-		<-ctx.Done()
 	})
 
 	svr.Serve(ctx)

--- a/init.go
+++ b/init.go
@@ -14,6 +14,7 @@ import (
 )
 
 func init() {
+	viper.AutomaticEnv() // picks up env vars automatically
 	cwd, err := os.Getwd()
 	if err != nil {
 		logrus.WithError(err).Fatalln("")
@@ -24,7 +25,6 @@ func init() {
 	viper.SetDefault(server.EnvDBURL, fmt.Sprintf("bolt://%s/data/bolt.db?bucket=funcs", cwd))
 	viper.SetDefault(server.EnvPort, 8080)
 	viper.SetDefault(server.EnvAPIURL, fmt.Sprintf("http://127.0.0.1:%d", viper.GetInt(server.EnvPort)))
-	viper.AutomaticEnv() // picks up env vars automatically
 	logLevel, err := logrus.ParseLevel(viper.GetString(server.EnvLogLevel))
 	if err != nil {
 		logrus.WithError(err).Fatalln("Invalid log level.")


### PR DESCRIPTION
- Fixed env PORT was not working correctly because viper.AutomaticEnv was positioned in the wrong place.
- API serve not using gin.Engine.Run because using that method we can't know when the server is already listening in the specified port.
- Some log changes

Closes #482