### PR TITLE
improve fn run/call http method support

### DIFF
--- a/fn/routes.go
+++ b/fn/routes.go
@@ -231,11 +231,19 @@ func (a *routesCmd) call(c *cli.Context) error {
 	u.Path = path.Join(u.Path, "r", appName, route)
 	content := stdin()
 
-	return callfn(u.String(), content, os.Stdout, c.StringSlice("e"))
+	return callfn(u.String(), content, os.Stdout, c.String("method"), c.StringSlice("e"))
 }
 
-func callfn(u string, content io.Reader, output io.Writer, env []string) error {
-	req, err := http.NewRequest("POST", u, content)
+func callfn(u string, content io.Reader, output io.Writer, method string, env []string) error {
+	if method == "" {
+		if content == nil {
+			method = "GET"
+		} else {
+			method = "POST"
+		}
+	}
+
+	req, err := http.NewRequest(method, u, content)
 	if err != nil {
 		return fmt.Errorf("error running route: %v", err)
 	}

--- a/fn/run_others.go
+++ b/fn/run_others.go
@@ -5,14 +5,12 @@ package main
 import (
 	"io"
 	"os"
-	"strings"
 )
 
 func stdin() io.Reader {
-	var stdin io.Reader = os.Stdin
 	stat, err := os.Stdin.Stat()
 	if err != nil || (stat.Mode()&os.ModeCharDevice) != 0 {
-		stdin = strings.NewReader("")
+		return nil
 	}
-	return stdin
+	return os.Stdin
 }

--- a/fn/run_windows.go
+++ b/fn/run_windows.go
@@ -5,17 +5,15 @@ package main
 import (
 	"io"
 	"os"
-	"strings"
 	"syscall"
 	"unsafe"
 )
 
 func stdin() io.Reader {
-	var stdin io.Reader = os.Stdin
 	if isTerminal(int(os.Stdin.Fd())) {
-		stdin = strings.NewReader("")
+		return nil
 	}
-	return stdin
+	return os.Stdin
 }
 
 func isTerminal(fd int) bool {

--- a/fn/testfn.go
+++ b/fn/testfn.go
@@ -134,7 +134,7 @@ func runlocaltest(target string, in, expectedOut, expectedErr *string, env map[s
 		restrictedEnv = append(restrictedEnv, k)
 	}
 
-	if err := runff(target, stdin, &stdout, &stderr, restrictedEnv, nil); err != nil {
+	if err := runff(target, stdin, &stdout, &stderr, "", restrictedEnv, nil); err != nil {
 		return fmt.Errorf("%v\nstdout:%s\nstderr:%s\n", err, stdout.String(), stderr.String())
 	}
 
@@ -172,7 +172,7 @@ func runremotetest(target string, in, expectedOut, expectedErr *string, env map[
 		os.Setenv(k, v)
 		restrictedEnv = append(restrictedEnv, k)
 	}
-	if err := callfn(target, stdin, &stdout, restrictedEnv); err != nil {
+	if err := callfn(target, stdin, &stdout, "", restrictedEnv); err != nil {
 		return fmt.Errorf("%v\nstdout:%s\n", err, stdout.String())
 	}
 


### PR DESCRIPTION
Fixes #503 

This change aligns `run` and `call`'s choice of http method in the default case (`POST` if data present, otherwise `GET`), and adds an explicit `method` flag as well.