### PR TITLE
Updates to enable local testing without Docker registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ This guide will get you up and running in a few minutes.
 To get started quickly with IronFunctions, just fire up an `iron/functions` container:
 
 ```sh
-docker run --rm -it --name functions --privileged -v ${PWD}/data:/app/data -p 8080:8080 iron/functions
+docker run --rm -it --name functions -v ${PWD}/data:/app/data -v /var/run/docker.sock:/var/run/docker.sock -p 8080:8080 iron/functions
 ```
 
 *where ${PWD}/data is the directory where the functions application data files will be stored*

--- a/api/server/routes_create.go
+++ b/api/server/routes_create.go
@@ -7,7 +7,6 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/iron-io/functions/api"
 	"github.com/iron-io/functions/api/models"
-	"github.com/iron-io/functions/api/runner/task"
 	"github.com/iron-io/runner/common"
 )
 
@@ -44,13 +43,13 @@ func (s *Server) handleRouteCreate(c *gin.Context) {
 		return
 	}
 
-	err = s.Runner.EnsureImageExists(ctx, &task.Config{
-		Image: wroute.Route.Image,
-	})
-	if err != nil {
-		c.JSON(http.StatusBadRequest, simpleError(models.ErrUsableImage))
-		return
-	}
+	// err = s.Runner.EnsureImageExists(ctx, &task.Config{
+	// 	Image: wroute.Route.Image,
+	// })
+	// if err != nil {
+	// 	c.JSON(http.StatusBadRequest, simpleError(models.ErrUsableImage))
+	// 	return
+	// }
 
 	app, err := s.Datastore.GetApp(ctx, wroute.Route.AppName)
 	if err != nil && err != models.ErrAppsNotFound {

--- a/api/server/routes_update.go
+++ b/api/server/routes_update.go
@@ -8,7 +8,6 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/iron-io/functions/api"
 	"github.com/iron-io/functions/api/models"
-	"github.com/iron-io/functions/api/runner/task"
 	"github.com/iron-io/runner/common"
 )
 
@@ -41,14 +40,14 @@ func (s *Server) handleRouteUpdate(c *gin.Context) {
 	wroute.Route.Path = path.Clean(c.MustGet(api.Path).(string))
 
 	if wroute.Route.Image != "" {
-		err = s.Runner.EnsureImageExists(ctx, &task.Config{
-			Image: wroute.Route.Image,
-		})
-		if err != nil {
-			log.WithError(err).Debug(models.ErrRoutesUpdate)
-			c.JSON(http.StatusBadRequest, simpleError(models.ErrUsableImage))
-			return
-		}
+		// err = s.Runner.EnsureImageExists(ctx, &task.Config{
+		// 	Image: wroute.Route.Image,
+		// })
+		// if err != nil {
+		// 	log.WithError(err).Debug(models.ErrRoutesUpdate)
+		// 	c.JSON(http.StatusBadRequest, simpleError(models.ErrUsableImage))
+		// 	return
+		// }
 	}
 
 	route, err := s.Datastore.UpdateRoute(ctx, wroute.Route)


### PR DESCRIPTION
Removes image check when updating routes to make local testing possible without having to push to docker hub. Also mounts the docker socket in the quickstart to enable this. 

Thoughts?

Closes #514 
Closes #348 
