### PR TITLE
server updates

### DIFF
--- a/api/models/app.go
+++ b/api/models/app.go
@@ -87,5 +87,6 @@ func (a *App) UpdateConfig(patch Config) {
 }
 
 type AppFilter struct {
+	// An SQL LIKE query. Empty does not filter.
 	Name string
 }

--- a/api/models/route.go
+++ b/api/models/route.go
@@ -87,6 +87,7 @@ func (r *Route) SetDefaults() {
 	}
 }
 
+// Validate validates field values, skipping zeroed fields if skipZero is true.
 func (r *Route) Validate(skipZero bool) error {
 	var res []error
 

--- a/api/models/route.go
+++ b/api/models/route.go
@@ -43,17 +43,18 @@ type Route struct {
 }
 
 var (
-	ErrRoutesValidationFoundDynamicURL = errors.New("Dynamic URL is not allowed")
-	ErrRoutesValidationInvalidPath     = errors.New("Invalid Path format")
-	ErrRoutesValidationInvalidType     = errors.New("Invalid route Type")
-	ErrRoutesValidationInvalidFormat   = errors.New("Invalid route Format")
-	ErrRoutesValidationMissingAppName  = errors.New("Missing route AppName")
-	ErrRoutesValidationMissingImage    = errors.New("Missing route Image")
-	ErrRoutesValidationMissingName     = errors.New("Missing route Name")
-	ErrRoutesValidationMissingPath     = errors.New("Missing route Path")
-	ErrRoutesValidationMissingType     = errors.New("Missing route Type")
-	ErrRoutesValidationPathMalformed   = errors.New("Path malformed")
-	ErrRoutesValidationNegativeTimeout = errors.New("Negative timeout")
+	ErrRoutesValidationFoundDynamicURL       = errors.New("Dynamic URL is not allowed")
+	ErrRoutesValidationInvalidPath           = errors.New("Invalid Path format")
+	ErrRoutesValidationInvalidType           = errors.New("Invalid route Type")
+	ErrRoutesValidationInvalidFormat         = errors.New("Invalid route Format")
+	ErrRoutesValidationMissingAppName        = errors.New("Missing route AppName")
+	ErrRoutesValidationMissingImage          = errors.New("Missing route Image")
+	ErrRoutesValidationMissingName           = errors.New("Missing route Name")
+	ErrRoutesValidationMissingPath           = errors.New("Missing route Path")
+	ErrRoutesValidationMissingType           = errors.New("Missing route Type")
+	ErrRoutesValidationPathMalformed         = errors.New("Path malformed")
+	ErrRoutesValidationNegativeTimeout       = errors.New("Negative timeout")
+	ErrRoutesValidationNegativeMaxConcurrency = errors.New("Negative MaxConcurrency")
 )
 
 // SetDefaults sets zeroed field to defaults.
@@ -132,7 +133,9 @@ func (r *Route) Validate(skipZero bool) error {
 		}
 	}
 
-	//TODO negative concurrency?
+	if r.MaxConcurrency < 0 {
+		res = append(res, ErrRoutesValidationNegativeMaxConcurrency)
+	}
 
 	if r.Timeout < 0 {
 		res = append(res, ErrRoutesValidationNegativeTimeout)

--- a/api/models/route_wrapper.go
+++ b/api/models/route_wrapper.go
@@ -6,10 +6,10 @@ type RouteWrapper struct {
 	Route *Route `json:"route"`
 }
 
-func (m *RouteWrapper) Validate() error {
+func (m *RouteWrapper) Validate(skipZero bool) error {
 	var res []error
 
-	if err := m.validateRoute(); err != nil {
+	if err := m.validateRoute(skipZero); err != nil {
 		res = append(res, err)
 	}
 
@@ -19,10 +19,10 @@ func (m *RouteWrapper) Validate() error {
 	return nil
 }
 
-func (m *RouteWrapper) validateRoute() error {
+func (m *RouteWrapper) validateRoute(skipZero bool) error {
 
 	if m.Route != nil {
-		if err := m.Route.Validate(); err != nil {
+		if err := m.Route.Validate(skipZero); err != nil {
 			return err
 		}
 	}

--- a/api/server/apps_delete.go
+++ b/api/server/apps_delete.go
@@ -22,7 +22,7 @@ func (s *Server) handleAppDelete(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, simpleError(ErrInternalServerError))
 		return
 	}
-
+	//TODO allow this? #528
 	if len(routes) > 0 {
 		log.WithError(err).Debug(models.ErrDeleteAppsWithRoutes)
 		c.JSON(http.StatusBadRequest, simpleError(models.ErrDeleteAppsWithRoutes))

--- a/api/server/routes_create.go
+++ b/api/server/routes_create.go
@@ -31,15 +31,11 @@ func (s *Server) handleRouteCreate(c *gin.Context) {
 
 	wroute.Route.AppName = c.MustGet(api.AppName).(string)
 
-	if err := wroute.Validate(); err != nil {
+	wroute.Route.SetDefaults()
+
+	if err := wroute.Validate(false); err != nil {
 		log.WithError(err).Debug(models.ErrRoutesCreate)
 		c.JSON(http.StatusBadRequest, simpleError(err))
-		return
-	}
-
-	if wroute.Route.Image == "" {
-		log.WithError(models.ErrRoutesValidationMissingImage).Debug(models.ErrRoutesCreate)
-		c.JSON(http.StatusBadRequest, simpleError(models.ErrRoutesValidationMissingImage))
 		return
 	}
 

--- a/api/server/routes_update.go
+++ b/api/server/routes_update.go
@@ -39,6 +39,12 @@ func (s *Server) handleRouteUpdate(c *gin.Context) {
 	wroute.Route.AppName = c.MustGet(api.AppName).(string)
 	wroute.Route.Path = path.Clean(c.MustGet(api.Path).(string))
 
+	if err := wroute.Validate(true); err != nil {
+		log.WithError(err).Debug(models.ErrRoutesUpdate)
+		c.JSON(http.StatusBadRequest, simpleError(err))
+		return
+	}
+
 	if wroute.Route.Image != "" {
 		// err = s.Runner.EnsureImageExists(ctx, &task.Config{
 		// 	Image: wroute.Route.Image,


### PR DESCRIPTION
This change picks out more pieces of #523.

- Splits route validation and defaults into separate methods to leverage from route create and update.
- Improved and additional route test cases.