### PR TITLE
Add Host header to function environ as HEADER_HOST

### DIFF
--- a/api/server/runner.go
+++ b/api/server/runner.go
@@ -184,6 +184,9 @@ func (s *Server) serve(ctx context.Context, c *gin.Context, appName string, foun
 	for header, value := range c.Request.Header {
 		envVars[toEnvName("HEADER", header)] = strings.Join(value, " ")
 	}
+	// revert Host header that is being prompted to c.Request.Host
+	// instead of being available as part of c.Requests.Header
+	envVars[toEnvName("HEADER", "Host")] = c.Request.Host
 
 	cfg := &task.Config{
 		AppName:        appName,


### PR DESCRIPTION
 From godoc:
	For incoming requests, the Host header is promoted to the
	Request.Host field and removed from the Header map.

 So, Host header is available at c.Request.Host.

 Fixes: #567