### PR TITLE
Make docker-test job pure Docker-based

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,6 @@ docker-test:
 	-v /var/run/docker.sock:/var/run/docker.sock \
 	-v ${CURDIR}:/go/src/github.com/iron-io/functions \
 	-w /go/src/github.com/iron-io/functions iron/go:dev go test \
-	-v $(shell go list ./... | grep -v vendor | grep -v examples | grep -v tool | grep -v fn | grep -v datastore)
+	-v $(shell docker run -ti -v ${CURDIR}:/go/src/github.com/iron-io/functions -w /go/src/github.com/iron-io/functions -e GOPATH=/go golang:alpine sh -c 'go list ./... | grep -v vendor | grep -v examples | grep -v tool | grep -v fn | grep -v datastore')
 
 all: dep build


### PR DESCRIPTION
 Using golang:alpine instead of host go binary

Fixes: #559 