### PR TITLE
Make datastore tests pass with remote Docker containers

### DIFF
--- a/api/datastore/internal/datastoretest/test.go
+++ b/api/datastore/internal/datastoretest/test.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"os"
 	"net/url"
+	"strings"
 )
 
 func setLogBuffer() *bytes.Buffer {
@@ -26,13 +27,26 @@ func setLogBuffer() *bytes.Buffer {
 	return &buf
 }
 
+// workaround for parts.Hostname() that doesn't work on Go1.7.1
+// TODO(denismakogon): remove this after switching to Go 1.8
+func stripPort(hostport string) string {
+	colon := strings.IndexByte(hostport, ':')
+	if colon == -1 {
+		return hostport
+	}
+	if i := strings.IndexByte(hostport, ']'); i != -1 {
+		return strings.TrimPrefix(hostport[:i], "[")
+	}
+	return hostport[:colon]
+}
+
 func GetContainerHostIP() string {
 	dockerHost := os.Getenv("DOCKER_HOST")
 	if dockerHost == "" {
 		return "127.0.0.1"
 	}
 	parts, _ := url.Parse(dockerHost)
-	return parts.Hostname()
+	return stripPort(parts.Host)
 }
 
 func Test(t *testing.T, ds models.Datastore) {

--- a/api/datastore/internal/datastoretest/test.go
+++ b/api/datastore/internal/datastoretest/test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/gin-gonic/gin"
 	"reflect"
 	"net/http"
+	"os"
+	"net/url"
 )
 
 func setLogBuffer() *bytes.Buffer {
@@ -22,6 +24,15 @@ func setLogBuffer() *bytes.Buffer {
 	gin.DefaultWriter = &buf
 	log.SetOutput(&buf)
 	return &buf
+}
+
+func GetContainerHostIP() string {
+	dockerHost := os.Getenv("DOCKER_HOST")
+	if dockerHost == "" {
+		return "127.0.0.1"
+	}
+	parts, _ := url.Parse(dockerHost)
+	return parts.Hostname()
 }
 
 func Test(t *testing.T, ds models.Datastore) {

--- a/api/datastore/redis/redis_test.go
+++ b/api/datastore/redis/redis_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/iron-io/functions/api/datastore/internal/datastoretest"
 )
 
-const tmpRedis = "redis://127.0.0.1:6301/"
+const tmpRedis = "redis://%v:6301/"
 
 func prepareRedisTest(logf, fatalf func(string, ...interface{})) (func(), func()) {
 	fmt.Println("initializing redis for test")
@@ -22,7 +22,7 @@ func prepareRedisTest(logf, fatalf func(string, ...interface{})) (func(), func()
 	timeout := time.After(20 * time.Second)
 
 	for {
-		c, err := redis.DialURL(tmpRedis)
+		c, err := redis.DialURL(fmt.Sprintf(tmpRedis, datastoretest.GetContainerHostIP()))
 		if err == nil {
 			_, err = c.Do("PING")
 			c.Close()
@@ -49,7 +49,7 @@ func TestDatastore(t *testing.T) {
 	_, close := prepareRedisTest(t.Logf, t.Fatalf)
 	defer close()
 
-	u, err := url.Parse(tmpRedis)
+	u, err := url.Parse(fmt.Sprintf(tmpRedis, datastoretest.GetContainerHostIP()))
 	if err != nil {
 		t.Fatal("failed to parse url: ", err)
 	}


### PR DESCRIPTION
 Make tests consume DOCKER_HOST IP address as
 bind host while constucting database URI.

 This fix makes datastore tests pass against
 remote Docker (with host IP different from 127.0.0.1)

Fixes: #586