### PR TITLE
Ensure can build ARM v5 or greater binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,12 @@ test:
 test-datastore:
 	cd api/datastore && go test -v ./...
 
+test-build-arm:
+    GOARCH=arm GOARM=5 $(MAKE) build
+    GOARCH=arm GOARM=6 $(MAKE) build
+    GOARCH=arm GOARM=7 $(MAKE) build
+    GOARCH=arm64 $(MAKE) build
+
 run:
 	./functions
 

--- a/circle.yml
+++ b/circle.yml
@@ -33,6 +33,8 @@ test:
         pwd: $GO_PROJECT
     - make test-datastore:
         pwd: $GO_PROJECT
+    - make test-build-arm:
+        pwd: $GO_PROJECT
     - go build:
         pwd: $GO_PROJECT/examples/middleware
     - go build:


### PR DESCRIPTION
 Add ARM v5 (or greater) binary builder to ensure support maintained

Depends-On: #590 