### PR TITLE
Add env vars for hotfunctions

### DIFF
--- a/api/runner/worker.go
+++ b/api/runner/worker.go
@@ -296,7 +296,6 @@ func (hc *htfn) serve(ctx context.Context) {
 	}()
 
 	cfg := *hc.cfg
-	cfg.Env["FN_HOT"] = "true"
 	cfg.Env["FN_FORMAT"] = cfg.Format
 	cfg.Timeout = 0 // add a timeout to simulate ab.end. failure.
 	cfg.Stdin = hc.containerIn

--- a/api/runner/worker.go
+++ b/api/runner/worker.go
@@ -296,6 +296,8 @@ func (hc *htfn) serve(ctx context.Context) {
 	}()
 
 	cfg := *hc.cfg
+	cfg.Env["FN_HOT"] = "true"
+	cfg.Env["FN_FORMAT"] = cfg.Format
 	cfg.Timeout = 0 // add a timeout to simulate ab.end. failure.
 	cfg.Stdin = hc.containerIn
 	cfg.Stdout = hc.containerOut


### PR DESCRIPTION
So functions can know if they are running as hot function or not and which format has been defined.