### PR TITLE
Solving postgres marshal/unmarshal issue

### DIFF
--- a/api/datastore/postgres/postgres.go
+++ b/api/datastore/postgres/postgres.go
@@ -122,7 +122,10 @@ func (ds *PostgresDatastore) UpdateApp(ctx context.Context, newapp *models.App) 
 		}
 
 		if len(config) > 0 {
-			json.Unmarshal([]byte(config), &app.Config)
+			err := json.Unmarshal([]byte(config), &app.Config)
+			if err != nil {
+				return err
+			}
 		}
 
 		app.UpdateConfig(newapp.Config)
@@ -183,7 +186,10 @@ func (ds *PostgresDatastore) GetApp(ctx context.Context, name string) (*models.A
 	}
 
 	if len(config) > 0 {
-		json.Unmarshal([]byte(config), &res.Config)
+		err := json.Unmarshal([]byte(config), &res.Config)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return res, nil
@@ -201,7 +207,10 @@ func scanApp(scanner rowScanner, app *models.App) error {
 	}
 
 	if len(configStr) > 0 {
-		json.Unmarshal([]byte(configStr), &app.Config)
+		err = json.Unmarshal([]byte(configStr), &app.Config)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -412,11 +421,17 @@ func scanRoute(scanner rowScanner, route *models.Route) error {
 	}
 
 	if len(headerStr) > 0 {
-		json.Unmarshal([]byte(headerStr), &route.Headers)
+		err = json.Unmarshal([]byte(headerStr), &route.Headers)
+		if err != nil {
+			return err
+		}
 	}
 
 	if len(configStr) > 0 {
-		json.Unmarshal([]byte(configStr), &route.Config)
+		err = json.Unmarshal([]byte(configStr), &route.Config)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/api/datastore/postgres/postgres.go
+++ b/api/datastore/postgres/postgres.go
@@ -121,9 +121,8 @@ func (ds *PostgresDatastore) UpdateApp(ctx context.Context, newapp *models.App) 
 			return err
 		}
 
-		err := json.Unmarshal([]byte(config), &app.Config)
-		if err != nil {
-			return err
+		if len(config) > 0 {
+			json.Unmarshal([]byte(config), &app.Config)
 		}
 
 		app.UpdateConfig(newapp.Config)

--- a/api/datastore/postgres/postgres.go
+++ b/api/datastore/postgres/postgres.go
@@ -121,11 +121,9 @@ func (ds *PostgresDatastore) UpdateApp(ctx context.Context, newapp *models.App) 
 			return err
 		}
 
-		if config != "" {
-			err := json.Unmarshal([]byte(config), &app.Config)
-			if err != nil {
-				return err
-			}
+		err := json.Unmarshal([]byte(config), &app.Config)
+		if err != nil {
+			return err
 		}
 
 		app.UpdateConfig(newapp.Config)
@@ -203,7 +201,11 @@ func scanApp(scanner rowScanner, app *models.App) error {
 		return err
 	}
 
-	return json.Unmarshal([]byte(configStr), &app.Config)
+	if len(configStr) > 0 {
+		json.Unmarshal([]byte(configStr), &app.Config)
+	}
+
+	return nil
 }
 
 func (ds *PostgresDatastore) GetApps(ctx context.Context, filter *models.AppFilter) ([]*models.App, error) {
@@ -410,14 +412,15 @@ func scanRoute(scanner rowScanner, route *models.Route) error {
 		return err
 	}
 
-	if headerStr == "" {
-		return models.ErrRoutesNotFound
+	if len(headerStr) > 0 {
+		json.Unmarshal([]byte(headerStr), &route.Headers)
 	}
 
-	if err := json.Unmarshal([]byte(headerStr), &route.Headers); err != nil {
-		return err
+	if len(configStr) > 0 {
+		json.Unmarshal([]byte(configStr), &route.Config)
 	}
-	return json.Unmarshal([]byte(configStr), &route.Config)
+
+	return nil
 }
 
 func (ds *PostgresDatastore) GetRoute(ctx context.Context, appName, routePath string) (*models.Route, error) {


### PR DESCRIPTION
Postgres datastore was not marshaling the App config during its insert, that behavior was resulting in issues when fetching the App and the datastore couldn't unmarshal the config.

The same issue was probably happening with the Route's headers in some situations.

This commit's idea is to always try to marshal configs and headers when inserting/updating Apps or Routes. But in Apps and Routes get methods, if the  config/headers unmarshal fails, it returns an empty config/headers.