### PR TITLE
Fix deps

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,12 @@
 
 
 [[projects]]
+  name = "cirello.io/supervisor"
+  packages = ["."]
+  revision = "3ae4051c50e006498b4b8aee130185a53caab86e"
+  version = "v0.5.3"
+
+[[projects]]
   branch = "master"
   name = "code.cloudfoundry.org/bytefmt"
   packages = ["."]
@@ -11,13 +17,13 @@
   branch = "master"
   name = "github.com/Azure/go-ansiterm"
   packages = [".","winterm"]
-  revision = "fa152c58bc15761d0200cb75fe958b89a9d4888e"
+  revision = "d6e3b3328b783f23731bc4d058875b0371ff8109"
 
 [[projects]]
   name = "github.com/Microsoft/go-winio"
   packages = ["."]
-  revision = "f533f7a102197536779ea3a8cb881d639e21ec5a"
-  version = "v0.4.2"
+  revision = "78439966b38d69bf38227fbf57ac8a6fee70f69a"
+  version = "v0.4.5"
 
 [[projects]]
   branch = "master"
@@ -35,13 +41,7 @@
   branch = "master"
   name = "github.com/PuerkitoBio/urlesc"
   packages = ["."]
-  revision = "bbf7a2afc14f93e1e0a5c06df524fbd75e5031e5"
-
-[[projects]]
-  name = "github.com/Sirupsen/logrus"
-  packages = [".","hooks/syslog"]
-  revision = "ba1b36c82c5e05c4f912a88eab0dcd91a171688f"
-  version = "v0.11.5"
+  revision = "de5bf2ad457846296e2031421a34e2568e304e35"
 
 [[projects]]
   branch = "master"
@@ -52,20 +52,26 @@
 [[projects]]
   name = "github.com/asaskevich/govalidator"
   packages = ["."]
-  revision = "4918b99a7cb949bb295f3c7bbaf24b577d806e35"
-  version = "v6"
+  revision = "521b25f4b05fd26bec69d9dedeb8f9c9a83939a8"
+  version = "v8"
 
 [[projects]]
   name = "github.com/aws/aws-sdk-go"
-  packages = ["aws","aws/awserr","aws/awsutil","aws/client","aws/client/metadata","aws/corehandlers","aws/credentials","aws/credentials/ec2rolecreds","aws/credentials/endpointcreds","aws/credentials/stscreds","aws/defaults","aws/ec2metadata","aws/endpoints","aws/request","aws/session","aws/signer/v4","private/protocol","private/protocol/json/jsonutil","private/protocol/jsonrpc","private/protocol/query","private/protocol/query/queryutil","private/protocol/rest","private/protocol/restjson","private/protocol/xml/xmlutil","service/lambda","service/sts"]
-  revision = "e0cdae7a65ba3a5e66a0af747a7b3967ddac099c"
-  version = "v1.8.30"
+  packages = ["aws","aws/awserr","aws/awsutil","aws/client","aws/client/metadata","aws/corehandlers","aws/credentials","aws/credentials/ec2rolecreds","aws/credentials/endpointcreds","aws/credentials/stscreds","aws/defaults","aws/ec2metadata","aws/endpoints","aws/request","aws/session","aws/signer/v4","internal/shareddefaults","private/protocol","private/protocol/json/jsonutil","private/protocol/jsonrpc","private/protocol/query","private/protocol/query/queryutil","private/protocol/rest","private/protocol/restjson","private/protocol/xml/xmlutil","service/lambda","service/sts"]
+  revision = "0c22c3d22be15d3be3d22b8dedabbf5dd4304730"
+  version = "v1.12.34"
+
+[[projects]]
+  name = "github.com/boltdb/bolt"
+  packages = ["."]
+  revision = "2f1ce7a837dcb8da3ec595b1dac9d0632f0f99e8"
+  version = "v1.3.1"
 
 [[projects]]
   branch = "master"
-  name = "github.com/boltdb/bolt"
-  packages = ["."]
-  revision = "e9cf4fae01b5a8ff89d0ec6b32f0d9c9f79aefdd"
+  name = "github.com/c0ze/runner"
+  packages = ["common","common/stats","drivers","drivers/docker","drivers/mock"]
+  revision = "2a7665f4e7ddb3e07eccb1a011c02c7fc9f449c2"
 
 [[projects]]
   name = "github.com/cactus/go-statsd-client"
@@ -76,8 +82,14 @@
 [[projects]]
   name = "github.com/cenkalti/backoff"
   packages = ["."]
-  revision = "32cd0c5b3aef12c76ed64aaf678f6c79736be7dc"
-  version = "v1.0.0"
+  revision = "61153c768f31ee5f130071d08fc82b85208528de"
+  version = "v1.1.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/containerd/continuity"
+  packages = ["pathdriver"]
+  revision = "0cf103d319cc2d7efe085224094f466d1f8b9640"
 
 [[projects]]
   name = "github.com/coreos/go-semver"
@@ -89,7 +101,7 @@
   branch = "master"
   name = "github.com/dghubble/go-twitter"
   packages = ["twitter"]
-  revision = "d7141a7cba567120d53d0a136fce068864b43f8c"
+  revision = "c4115fa44a928413e0b857e0eb47376ffde3a61a"
 
 [[projects]]
   name = "github.com/dghubble/oauth1"
@@ -106,32 +118,30 @@
 [[projects]]
   name = "github.com/dgrijalva/jwt-go"
   packages = [".","request"]
-  revision = "d2709f9f1f31ebcda9651b03077758c1f3a0018c"
-  version = "v3.0.0"
+  revision = "dbeaa9332f19a944acb5736b4456cfcc02140e29"
+  version = "v3.1.0"
 
 [[projects]]
   name = "github.com/docker/distribution"
-  packages = [".","context","digest","manifest","manifest/schema1","manifest/schema2","reference","uuid"]
-  revision = "a25b9ef0c9fe242ac04bb20d3a028442b7d266b6"
-  version = "v2.6.1"
+  packages = [".","digestset","manifest","manifest/schema1","manifest/schema2","reference"]
+  revision = "30578ca32960a4d368bf6db67b0a33c2a1f3dc6f"
 
 [[projects]]
   name = "github.com/docker/docker"
-  packages = ["api/types","api/types/blkiodev","api/types/container","api/types/filters","api/types/mount","api/types/network","api/types/registry","api/types/strslice","api/types/swarm","api/types/versions","opts","pkg/archive","pkg/fileutils","pkg/homedir","pkg/idtools","pkg/ioutils","pkg/jsonlog","pkg/jsonmessage","pkg/longpath","pkg/pools","pkg/promise","pkg/stdcopy","pkg/system","pkg/term","pkg/term/windows"]
-  revision = "90d35abf7b3535c1c319c872900fbd76374e521c"
-  version = "v17.05.0-ce-rc3"
+  packages = ["api/types","api/types/blkiodev","api/types/container","api/types/filters","api/types/mount","api/types/network","api/types/registry","api/types/strslice","api/types/swarm","api/types/swarm/runtime","api/types/versions","opts","pkg/archive","pkg/fileutils","pkg/homedir","pkg/idtools","pkg/ioutils","pkg/jsonmessage","pkg/longpath","pkg/mount","pkg/pools","pkg/stdcopy","pkg/system","pkg/term","pkg/term/windows"]
+  revision = "fe8aac6f5ae413a967adb0adad0b54abdfb825c4"
 
 [[projects]]
   name = "github.com/docker/go-connections"
   packages = ["nat"]
-  revision = "990a1a1a70b0da4c4cb70e117971a4f0babfbf1a"
-  version = "v0.2.1"
+  revision = "3ede32e2033de7505e6500d6c868c2b9ed9f169d"
+  version = "v0.3.0"
 
 [[projects]]
   name = "github.com/docker/go-units"
   packages = ["."]
-  revision = "f2d77a61e3c169b43402a0a1e84f06daf29b8190"
-  version = "v0.3.1"
+  revision = "0dadbb0345b35ec7ef35e228dabb8de89a65bf52"
+  version = "v0.3.2"
 
 [[projects]]
   branch = "master"
@@ -146,16 +156,16 @@
   version = "v1.4.2"
 
 [[projects]]
-  branch = "master"
   name = "github.com/fsouza/go-dockerclient"
   packages = ["."]
-  revision = "c933ed18bef34ec2955de03de8ef9a3bb996e3df"
+  revision = "2ff310040c161b75fa19fb9b287a90a6e03c0012"
+  version = "1.1"
 
 [[projects]]
   name = "github.com/garyburd/redigo"
   packages = ["internal","redis"]
-  revision = "433969511232c397de61b1442f9fd49ec06ae9ba"
-  version = "v1.1.0"
+  revision = "47dc60e71eed504e3ef8e77ee3c6fe720f3be57f"
+  version = "v1.3.0"
 
 [[projects]]
   name = "github.com/giantswarm/semver-bump"
@@ -164,22 +174,28 @@
   version = "1.1.1"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/gin-contrib/sse"
+  packages = ["."]
+  revision = "22d885f9ecc78bf4ee5d72b937e4bbcdc58e8cae"
+
+[[projects]]
   name = "github.com/gin-gonic/gin"
   packages = [".","binding","render"]
-  revision = "e2212d40c62a98b388a5eb48ecbdcf88534688ba"
-  version = "v1.1.4"
+  revision = "d459835d2b077e44f7c9b453505ee29881d5d12d"
+  version = "v1.2"
 
 [[projects]]
   name = "github.com/go-ini/ini"
   packages = ["."]
-  revision = "36da989cdc560b989d8f195aec46214d33665d20"
-  version = "v1.27.2"
+  revision = "32e4c1e6bc4e7d0d8451aa6b75200d19e37a536a"
+  version = "v1.32.0"
 
 [[projects]]
   branch = "master"
   name = "github.com/go-openapi/analysis"
   packages = ["."]
-  revision = "0473cb67199f68b8b7d90e641afd9e79ad36b851"
+  revision = "8ed83f2ea9f00f945516462951a288eaa68bf0d6"
 
 [[projects]]
   branch = "master"
@@ -203,43 +219,43 @@
   branch = "master"
   name = "github.com/go-openapi/loads"
   packages = [".","fmts"]
-  revision = "a80dea3052f00e5f032e860dd7355cd0cc67e24d"
+  revision = "c3e1ca4c0b6160cac10aeef7e8b425cc95b9c820"
 
 [[projects]]
   branch = "master"
   name = "github.com/go-openapi/runtime"
-  packages = [".","client"]
-  revision = "2e9e988df6c290425033bacd425e008950c96be6"
+  packages = [".","client","logger","middleware","middleware/denco","middleware/header","middleware/untyped","security"]
+  revision = "94927f8c9742791a9aa46c6c3965f0a37025f41d"
 
 [[projects]]
   branch = "master"
   name = "github.com/go-openapi/spec"
   packages = ["."]
-  revision = "e51c28f07047ad90caff03f6450908720d337e0c"
+  revision = "bfb48d37839bcacb52be3f539ffac5abcda7e195"
 
 [[projects]]
   branch = "master"
   name = "github.com/go-openapi/strfmt"
   packages = ["."]
-  revision = "93a31ef21ac23f317792fff78f9539219dd74619"
+  revision = "610b6cacdcde6852f4de68998bd20ce1dac85b22"
 
 [[projects]]
   branch = "master"
   name = "github.com/go-openapi/swag"
   packages = ["."]
-  revision = "e43299b4afa7bc7f22e5e82e3d48607230e4c177"
+  revision = "cf0bdb963811675a4d7e74901cefc7411a1df939"
 
 [[projects]]
   branch = "master"
   name = "github.com/go-openapi/validate"
   packages = ["."]
-  revision = "035dcd74f1f61e83debe1c22950dc53556e7e4b2"
+  revision = "d509235108fcf6ab4913d2dcb3a2260c0db2108e"
 
 [[projects]]
   name = "github.com/go-resty/resty"
   packages = ["."]
-  revision = "7a8134d8718193eb857994adee49d73a302e7718"
-  version = "v0.12"
+  revision = "9ac9c42358f7c3c69ac9f8610e8790d7c338e85d"
+  version = "v1.0"
 
 [[projects]]
   name = "github.com/go-sql-driver/mysql"
@@ -248,16 +264,22 @@
   version = "v1.3"
 
 [[projects]]
+  name = "github.com/gogo/protobuf"
+  packages = ["proto"]
+  revision = "342cbe0a04158f6dcb03ca0079991a51a4248c02"
+  version = "v0.5"
+
+[[projects]]
   branch = "master"
   name = "github.com/golang/groupcache"
   packages = ["consistenthash","singleflight"]
-  revision = "b710c8433bd175204919eb38776e944233235d03"
+  revision = "84a468cf14b4376def5d68c722b139b881c450a4"
 
 [[projects]]
   branch = "master"
   name = "github.com/golang/protobuf"
   packages = ["proto"]
-  revision = "9f174c986221c608fb5143bd623b6076a71feae3"
+  revision = "1e59b77b52bf8e4b449a57e6f79f21226d571845"
 
 [[projects]]
   branch = "master"
@@ -272,34 +294,16 @@
   revision = "53e6ce116135b80d037921a7fdd5138cf32d7a8a"
 
 [[projects]]
-  name = "github.com/gorilla/context"
-  packages = ["."]
-  revision = "1ea25387ff6f684839d82767c1733ff4d4d15d0a"
-  version = "v1.1"
-
-[[projects]]
-  name = "github.com/gorilla/mux"
-  packages = ["."]
-  revision = "bcd8bc72b08df0f70df986b97f95590779502d31"
-  version = "v1.4.0"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/hashicorp/go-cleanhttp"
-  packages = ["."]
-  revision = "3573b8b52aa7b37b9358d966a898feb387f62437"
-
-[[projects]]
   branch = "master"
   name = "github.com/hashicorp/hcl"
   packages = [".","hcl/ast","hcl/parser","hcl/scanner","hcl/strconv","hcl/token","json/parser","json/scanner","json/token"]
-  revision = "392dba7d905ed5d04a5794ba89f558b27e2ba1ca"
+  revision = "23c074d0eceb2b8a5bfdbb271ab780cde70f05a8"
 
 [[projects]]
   branch = "master"
-  name = "github.com/heroku/docker-registry-client"
+  name = "github.com/iron-io/docker-registry-client"
   packages = ["registry"]
-  revision = "95467b6cacee2a06f112a3cf7e47a70fad6000cf"
+  revision = "943bcd9912a68f76929402d5cf94622a4fa4694f"
 
 [[projects]]
   branch = "master"
@@ -311,19 +315,12 @@
   branch = "master"
   name = "github.com/iron-io/iron_go3"
   packages = ["api","config","mq"]
-  revision = "830335d420db87fc84cbff7f0d1348a46b499946"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/iron-io/runner"
-  packages = ["common","common/stats","drivers","drivers/docker","drivers/mock"]
-  revision = "0f2736fbfb404bdc882c70fd0c498176afc020a7"
+  revision = "ded317cb147d3b52b593da08495bc7d53efa17d8"
 
 [[projects]]
   name = "github.com/jmespath/go-jmespath"
   packages = ["."]
-  revision = "3433f3ea46d9f8019119e7dd41274e112a2359a9"
-  version = "0.2.2"
+  revision = "0b12d6b5"
 
 [[projects]]
   branch = "master"
@@ -341,43 +338,43 @@
   branch = "master"
   name = "github.com/lib/pq"
   packages = [".","oid"]
-  revision = "2704adc878c21e1329f46f6e56a1c387d788ff94"
+  revision = "83612a56d3dd153a94a629cd64925371c9adad78"
 
 [[projects]]
   name = "github.com/magiconair/properties"
   packages = ["."]
-  revision = "f917359f079a3759162704eaa8caeec3d01d9f91"
-  version = "v1.7.2"
+  revision = "be5ece7dd465ab0765a9682137865547526d1dfb"
+  version = "v1.7.3"
 
 [[projects]]
   branch = "master"
   name = "github.com/mailru/easyjson"
   packages = ["buffer","jlexer","jwriter"]
-  revision = "44c0351a5bc860bcb2608d54aa03ea686c4e7b25"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/manucorporat/sse"
-  packages = ["."]
-  revision = "ee05b128a739a0fb76c7ebd3ae4810c1de808d6d"
+  revision = "32fa128f234d041f196a9f3e0fea5ac9772c08e1"
 
 [[projects]]
   name = "github.com/mattn/go-isatty"
   packages = ["."]
-  revision = "fc9e8d8ef48496124e79ae0df75490096eccf6fe"
-  version = "v0.0.2"
+  revision = "0360b2af4f38e8d38c7fce2a9f4e702702d73a39"
+  version = "v0.0.3"
 
 [[projects]]
   branch = "master"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
-  revision = "d0303fe809921458f417bcf828397a65db30a7e4"
+  revision = "06020f85339e21b2478f756a78e295255ffa4d6a"
 
 [[projects]]
-  name = "github.com/moby/moby"
-  packages = ["cli/config/configfile"]
-  revision = "90d35abf7b3535c1c319c872900fbd76374e521c"
-  version = "v17.05.0-ce-rc3"
+  name = "github.com/opencontainers/go-digest"
+  packages = ["."]
+  revision = "279bed98673dd5bef374d3b6e4b09e2af76183bf"
+  version = "v1.0.0-rc1"
+
+[[projects]]
+  name = "github.com/opencontainers/image-spec"
+  packages = ["specs-go","specs-go/v1"]
+  revision = "d60099175f88c47cd379c4738d158884749ed235"
+  version = "v1.0.1"
 
 [[projects]]
   name = "github.com/opencontainers/runc"
@@ -386,16 +383,10 @@
   version = "v0.1.1"
 
 [[projects]]
-  name = "github.com/pelletier/go-buffruneio"
-  packages = ["."]
-  revision = "c37440a7cf42ac63b919c752ca73a85067e05992"
-  version = "v0.2.0"
-
-[[projects]]
   name = "github.com/pelletier/go-toml"
   packages = ["."]
-  revision = "13d49d4606eb801b8f01ae542b4afc4c6ee3d84a"
-  version = "v0.5.0"
+  revision = "16398bac157da96aa88f98a2df640c7f32af1da2"
+  version = "v1.0.1"
 
 [[projects]]
   branch = "master"
@@ -404,10 +395,10 @@
   revision = "53be0d36a84c2a886ca057d34b6aa4468df9ccb4"
 
 [[projects]]
-  branch = "master"
   name = "github.com/pkg/errors"
   packages = ["."]
-  revision = "c605e284fe17294bda444b34710735b29d1a9d90"
+  revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
+  version = "v0.8.0"
 
 [[projects]]
   name = "github.com/satori/go.uuid"
@@ -416,10 +407,16 @@
   version = "v1.1.0"
 
 [[projects]]
-  branch = "master"
+  name = "github.com/sirupsen/logrus"
+  packages = [".","hooks/syslog"]
+  revision = "f006c2ac4710855cf0f916dd6b77acf6b048dc6e"
+  version = "v1.0.3"
+
+[[projects]]
   name = "github.com/spf13/afero"
   packages = [".","mem"]
-  revision = "9be650865eab0c12963d8753212f4f9c66cdcf12"
+  revision = "8d919cbe7e2627e417f3e45c3c0e489a5b7e2536"
+  version = "v1.0.0"
 
 [[projects]]
   name = "github.com/spf13/cast"
@@ -431,61 +428,61 @@
   branch = "master"
   name = "github.com/spf13/jwalterweatherman"
   packages = ["."]
-  revision = "0efa5202c04663c757d84f90f5219c1250baf94f"
+  revision = "12bd96e66386c1960ab0f74ced1362f66f552f7b"
 
 [[projects]]
-  branch = "master"
   name = "github.com/spf13/pflag"
   packages = ["."]
   revision = "e57e3eeb33f795204c1ca35f56c44f83227c6e66"
+  version = "v1.0.0"
+
+[[projects]]
+  name = "github.com/spf13/viper"
+  packages = ["."]
+  revision = "25b30aa063fc18e48662b86996252eabdcf2f0c7"
+  version = "v1.0.0"
 
 [[projects]]
   branch = "master"
-  name = "github.com/spf13/viper"
-  packages = ["."]
-  revision = "0967fc9aceab2ce9da34061253ac10fb99bba5b2"
-
-[[projects]]
-  name = "github.com/ucirello/supervisor"
-  packages = ["."]
-  revision = "f1f5037005c3f2655a1419fe78242583ca60132c"
-  version = "v0.5.2"
+  name = "github.com/ugorji/go"
+  packages = ["codec"]
+  revision = "84cb69a8af8316eed8cf4a3c9368a56977850062"
 
 [[projects]]
   name = "github.com/urfave/cli"
   packages = ["."]
-  revision = "0bdeddeeb0f650497d603c4ad7b20cfe685682f6"
-  version = "v1.19.1"
+  revision = "cfb38830724cc34fedffe9a2a29fb54fa9169cd1"
+  version = "v1.20.0"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/crypto"
-  packages = ["bcrypt","blowfish"]
-  revision = "7e9105388ebff089b3f99f0ef676ea55a6da3a7e"
+  packages = ["bcrypt","blowfish","ssh/terminal"]
+  revision = "e8f229864d71a49e5fdc4a9a134c5f85c4c33d64"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
   packages = ["context","context/ctxhttp","idna","proxy","publicsuffix"]
-  revision = "3da985ce5951d99de868be4385f21ea6c2b22f24"
+  revision = "6921abc35dffd00438a0c020584ce560108737ea"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
   packages = ["unix","windows"]
-  revision = "b90f89a1e7a9c1f6b918820b3daa7f08488c8594"
+  revision = "b76f9891dc1d975623261def70f9b89661f5baab"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/text"
-  packages = ["internal/gen","internal/triegen","internal/ucd","secure/bidirule","transform","unicode/bidi","unicode/cldr","unicode/norm","unicode/rangetable","width"]
-  revision = "19e51611da83d6be54ddafce4a4af510cb3e9ea4"
+  packages = ["collate","collate/build","internal/colltab","internal/gen","internal/tag","internal/triegen","internal/ucd","language","secure/bidirule","transform","unicode/bidi","unicode/cldr","unicode/norm","unicode/rangetable","width"]
+  revision = "572a2b141f625f4360cf42a41a43622067e0510b"
 
 [[projects]]
   name = "gopkg.in/go-playground/validator.v8"
   packages = ["."]
-  revision = "5f57d2222ad794d0dffb07e664ea05e2ee07d60c"
-  version = "v8.18.1"
+  revision = "5f1438d3fca68893a817e4a66806cea46a9e4ebf"
+  version = "v8.18.2"
 
 [[projects]]
   branch = "v2"
@@ -497,11 +494,11 @@
   branch = "v2"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  revision = "cd8b52f8269e0feb286dfeef29f8fe4d5b397e0b"
+  revision = "287cf08546ab5e7e37d55a84f7ed3fd1db036de5"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "ef62003d4ceb634fb5518324069e8f30e46dd1df5ec5de8527789f2acf0a1c72"
+  inputs-digest = "ce77853bc0905886496265ce8cc0c071a332c7a8126b55fb98dcbdd36adc9ce6"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,192 +1,162 @@
 
-## Gopkg.toml example (these lines may be deleted)
-
-## "required" lists a set of packages (not projects) that must be included in
-## Gopkg.lock. This list is merged with the set of packages imported by the current
-## project. Use it when your project needs a package it doesn't explicitly import -
-## including "main" packages.
+# Gopkg.toml example
+#
+# Refer to https://github.com/golang/dep/blob/master/docs/Gopkg.toml.md
+# for detailed Gopkg.toml documentation.
+#
 # required = ["github.com/user/thing/cmd/thing"]
-
-## "ignored" lists a set of packages (not projects) that are ignored when
-## dep statically analyzes source code. Ignored packages can be in this project,
-## or in a dependency.
-# ignored = ["github.com/user/project/badpkg"]
-
-## Dependencies define constraints on dependent projects. They are respected by
-## dep whether coming from the Gopkg.toml of the current project or a dependency.
-# [[dependencies]]
-## Required: the root import path of the project being constrained.
-# name = "github.com/user/project"
+# ignored = ["github.com/user/project/pkgX", "bitbucket.org/user/project/pkgA/pkgY"]
 #
-## Recommended: the version constraint to enforce for the project.
-## Only one of "branch", "version" or "revision" can be specified.
-# version = "1.0.0"
-# branch = "master"
-# revision = "abc123"
+# [[constraint]]
+#   name = "github.com/user/project"
+#   version = "1.0.0"
 #
-## Optional: an alternate location (URL or import path) for the project's source.
-# source = "https://github.com/myfork/package.git"
-
-## Overrides have the same structure as [[dependencies]], but supercede all
-## [[dependencies]] declarations from all projects. Only the current project's
-## [[overrides]] are applied.
-##
-## Overrides are a sledgehammer. Use them only as a last resort.
-# [[overrides]]
-## Required: the root import path of the project being constrained.
-# name = "github.com/user/project"
+# [[constraint]]
+#   name = "github.com/user/project2"
+#   branch = "dev"
+#   source = "github.com/myfork/project2"
 #
-## Optional: specifying a version constraint override will cause all other
-## constraints on this project to be ignored; only the overriden constraint
-## need be satisfied.
-## Again, only one of "branch", "version" or "revision" can be specified.
-# version = "1.0.0"
-# branch = "master"
-# revision = "abc123"
-#
-## Optional: specifying an alternate source location as an override will
-## enforce that the alternate location is used for that project, regardless of
-## what source location any dependent projects specify.
-# source = "https://github.com/myfork/package.git"
+# [[override]]
+#  name = "github.com/x/y"
+#  version = "2.4.0"
 
 
+[[constraint]]
+  name = "cirello.io/supervisor"
+  version = "0.5.3"
 
-[[dependencies]]
-  name = "github.com/Sirupsen/logrus"
-  version = "^0.11.5"
-
-[[dependencies]]
+[[constraint]]
   name = "github.com/aws/aws-sdk-go"
-  version = "^1.8.30"
+  version = "1.12.34"
 
-[[dependencies]]
-  branch = "master"
+[[constraint]]
   name = "github.com/boltdb/bolt"
+  version = "1.3.1"
 
-[[dependencies]]
-  name = "github.com/ucirello/supervisor"
-  version = "^0.5.3"
+[[constraint]]
+  branch = "master"
+  name = "github.com/c0ze/runner"
 
-[[dependencies]]
+[[constraint]]
   branch = "master"
   name = "github.com/dghubble/go-twitter"
 
-[[dependencies]]
+[[constraint]]
   name = "github.com/dghubble/oauth1"
-  version = "^0.4.0"
+  version = "0.4.0"
 
-[[dependencies]]
+[[constraint]]
   name = "github.com/dgrijalva/jwt-go"
-  version = "^3.0.0"
+  version = "3.1.0"
 
-[[dependencies]]
-  name = "github.com/docker/docker"
-  version = "^17.5.0-ce-rc3"
-
-[[dependencies]]
-  branch = "master"
+[[constraint]]
   name = "github.com/fsouza/go-dockerclient"
+  version = "1.1.0"
 
-[[dependencies]]
+[[constraint]]
   name = "github.com/garyburd/redigo"
-  version = "^1.1.0"
+  version = "1.3.0"
 
-[[dependencies]]
+[[constraint]]
   name = "github.com/giantswarm/semver-bump"
-  version = "^1.1.1"
+  version = "1.1.1"
 
-[[dependencies]]
+[[constraint]]
   name = "github.com/gin-gonic/gin"
-  version = "^1.1.4"
+  version = "1.2.0"
 
-[[dependencies]]
+[[constraint]]
   branch = "master"
   name = "github.com/go-openapi/errors"
 
-[[dependencies]]
+[[constraint]]
   branch = "master"
   name = "github.com/go-openapi/loads"
 
-[[dependencies]]
+[[constraint]]
   branch = "master"
   name = "github.com/go-openapi/runtime"
 
-[[dependencies]]
+[[constraint]]
   branch = "master"
   name = "github.com/go-openapi/spec"
 
-[[dependencies]]
+[[constraint]]
   branch = "master"
   name = "github.com/go-openapi/strfmt"
 
-[[dependencies]]
+[[constraint]]
   branch = "master"
   name = "github.com/go-openapi/swag"
 
-[[dependencies]]
+[[constraint]]
   branch = "master"
   name = "github.com/go-openapi/validate"
 
-[[dependencies]]
-  name = "github.com/go-sql-driver/mysql"
-  version = "^1.3.0"
+[[constraint]]
+  name = "github.com/go-resty/resty"
+  version = "1.0.0"
 
-[[dependencies]]
+[[constraint]]
+  name = "github.com/go-sql-driver/mysql"
+  version = "1.3.0"
+
+[[constraint]]
   branch = "master"
   name = "github.com/golang/groupcache"
 
-[[dependencies]]
+[[constraint]]
   branch = "master"
   name = "github.com/google/btree"
 
-[[dependencies]]
+[[constraint]]
   branch = "master"
   name = "github.com/iron-io/functions_go"
 
-[[dependencies]]
+[[constraint]]
   branch = "master"
   name = "github.com/iron-io/iron_go3"
 
-[[dependencies]]
-  branch = "master"
-  name = "github.com/iron-io/runner"
-
-[[dependencies]]
+[[constraint]]
   branch = "master"
   name = "github.com/jmoiron/jsonq"
 
-[[dependencies]]
+[[constraint]]
   branch = "master"
   name = "github.com/lib/pq"
 
-[[dependencies]]
-  branch = "master"
+[[constraint]]
   name = "github.com/pkg/errors"
+  version = "0.8.0"
 
-[[dependencies]]
+[[constraint]]
   name = "github.com/satori/go.uuid"
-  version = "^1.1.0"
+  version = "1.1.0"
 
-[[dependencies]]
-  branch = "master"
+[[constraint]]
+  name = "github.com/sirupsen/logrus"
+  version = "1.0.3"
+
+[[constraint]]
   name = "github.com/spf13/viper"
+  version = "1.0.0"
 
-[[dependencies]]
+[[constraint]]
   name = "github.com/urfave/cli"
-  version = "^1.19.1"
+  version = "1.20.0"
 
-[[dependencies]]
+[[constraint]]
   branch = "master"
   name = "golang.org/x/crypto"
 
-[[dependencies]]
+[[constraint]]
   branch = "master"
-  name = "golang.org/x/sys"
+  name = "golang.org/x/net"
 
-[[dependencies]]
+[[constraint]]
   branch = "v2"
   name = "gopkg.in/mgo.v2"
 
-[[dependencies]]
+[[constraint]]
   branch = "v2"
   name = "gopkg.in/yaml.v2"

--- a/api/datastore/bolt/bolt.go
+++ b/api/datastore/bolt/bolt.go
@@ -12,10 +12,10 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/boltdb/bolt"
 	"github.com/iron-io/functions/api/datastore/internal/datastoreutil"
 	"github.com/iron-io/functions/api/models"
+	"github.com/sirupsen/logrus"
 )
 
 type BoltDatastore struct {

--- a/api/datastore/datastore.go
+++ b/api/datastore/datastore.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/iron-io/functions/api/datastore/bolt"
 	"github.com/iron-io/functions/api/datastore/mysql"
 	"github.com/iron-io/functions/api/datastore/postgres"
 	"github.com/iron-io/functions/api/datastore/redis"
 	"github.com/iron-io/functions/api/models"
+	"github.com/sirupsen/logrus"
 )
 
 func New(dbURL string) (models.Datastore, error) {

--- a/api/datastore/internal/datastoretest/test.go
+++ b/api/datastore/internal/datastoretest/test.go
@@ -13,8 +13,8 @@ import (
 	"os"
 	"reflect"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
 )
 
 func setLogBuffer() *bytes.Buffer {

--- a/api/datastore/mysql/mysql.go
+++ b/api/datastore/mysql/mysql.go
@@ -8,11 +8,11 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/go-sql-driver/mysql"
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/iron-io/functions/api/datastore/internal/datastoreutil"
 	"github.com/iron-io/functions/api/models"
+	"github.com/sirupsen/logrus"
 )
 
 const routesTableCreate = `CREATE TABLE IF NOT EXISTS routes (

--- a/api/datastore/postgres/postgres.go
+++ b/api/datastore/postgres/postgres.go
@@ -9,11 +9,11 @@ import (
 	"context"
 
 	"bytes"
-	"github.com/Sirupsen/logrus"
 	"github.com/iron-io/functions/api/datastore/internal/datastoreutil"
 	"github.com/iron-io/functions/api/models"
 	"github.com/lib/pq"
 	_ "github.com/lib/pq"
+	"github.com/sirupsen/logrus"
 )
 
 const routesTableCreate = `

--- a/api/datastore/redis/redis.go
+++ b/api/datastore/redis/redis.go
@@ -10,10 +10,10 @@ import (
 
 	"context"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/garyburd/redigo/redis"
 	"github.com/iron-io/functions/api/datastore/internal/datastoreutil"
 	"github.com/iron-io/functions/api/models"
+	"github.com/sirupsen/logrus"
 )
 
 type RedisDataStore struct {

--- a/api/mqs/bolt.go
+++ b/api/mqs/bolt.go
@@ -11,10 +11,10 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/boltdb/bolt"
+	"github.com/c0ze/runner/common"
 	"github.com/iron-io/functions/api/models"
-	"github.com/iron-io/runner/common"
+	"github.com/sirupsen/logrus"
 )
 
 type BoltDbMQ struct {

--- a/api/mqs/ironmq.go
+++ b/api/mqs/ironmq.go
@@ -9,10 +9,10 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/iron-io/functions/api/models"
 	mq_config "github.com/iron-io/iron_go3/config"
 	ironmq "github.com/iron-io/iron_go3/mq"
+	"github.com/sirupsen/logrus"
 )
 
 type assoc struct {

--- a/api/mqs/memory.go
+++ b/api/mqs/memory.go
@@ -7,10 +7,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/c0ze/runner/common"
 	"github.com/google/btree"
 	"github.com/iron-io/functions/api/models"
-	"github.com/iron-io/runner/common"
+	"github.com/sirupsen/logrus"
 )
 
 type MemoryMQ struct {

--- a/api/mqs/new.go
+++ b/api/mqs/new.go
@@ -5,8 +5,8 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/iron-io/functions/api/models"
+	"github.com/sirupsen/logrus"
 )
 
 // New will parse the URL and return the correct MQ implementation.

--- a/api/mqs/redis.go
+++ b/api/mqs/redis.go
@@ -9,10 +9,10 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/c0ze/runner/common"
 	"github.com/garyburd/redigo/redis"
 	"github.com/iron-io/functions/api/models"
-	"github.com/iron-io/runner/common"
+	"github.com/sirupsen/logrus"
 )
 
 type RedisMQ struct {

--- a/api/runner/async_runner.go
+++ b/api/runner/async_runner.go
@@ -13,10 +13,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/c0ze/runner/common"
 	"github.com/iron-io/functions/api/models"
 	"github.com/iron-io/functions/api/runner/task"
-	"github.com/iron-io/runner/common"
+	"github.com/sirupsen/logrus"
 )
 
 func getTask(ctx context.Context, url string) (*models.Task, error) {

--- a/api/runner/async_runner_test.go
+++ b/api/runner/async_runner_test.go
@@ -13,11 +13,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/gin-gonic/gin"
 	"github.com/iron-io/functions/api/models"
 	"github.com/iron-io/functions/api/mqs"
 	"github.com/iron-io/functions/api/runner/task"
+	"github.com/sirupsen/logrus"
 )
 
 func setLogBuffer() *bytes.Buffer {

--- a/api/runner/configfile.go
+++ b/api/runner/configfile.go
@@ -12,7 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 
-//	"github.com/docker/docker/api/types"
+	//	"github.com/docker/docker/api/types"
 	"github.com/pkg/errors"
 )
 

--- a/api/runner/configfile.go
+++ b/api/runner/configfile.go
@@ -12,7 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	//	"github.com/docker/docker/api/types"
+	"github.com/moby/moby/api/types"
 	"github.com/pkg/errors"
 )
 

--- a/api/runner/configfile.go
+++ b/api/runner/configfile.go
@@ -1,0 +1,190 @@
+package runner
+
+// resurrected from docker repo
+// https://github.com/moby/moby/blob/7b7ea8ab810190018346cb7d84c161bb94f7ca60/cli/config/configfile/file.go
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+//	"github.com/docker/docker/api/types"
+	"github.com/pkg/errors"
+)
+
+const (
+	// This constant is only used for really old config files when the
+	// URL wasn't saved as part of the config file and it was just
+	// assumed to be this value.
+	defaultIndexserver = "https://index.docker.io/v1/"
+)
+
+// ConfigFile ~/.docker/config.json file info
+type ConfigFile struct {
+	AuthConfigs          map[string]types.AuthConfig `json:"auths"`
+	HTTPHeaders          map[string]string           `json:"HttpHeaders,omitempty"`
+	PsFormat             string                      `json:"psFormat,omitempty"`
+	ImagesFormat         string                      `json:"imagesFormat,omitempty"`
+	NetworksFormat       string                      `json:"networksFormat,omitempty"`
+	PluginsFormat        string                      `json:"pluginsFormat,omitempty"`
+	VolumesFormat        string                      `json:"volumesFormat,omitempty"`
+	StatsFormat          string                      `json:"statsFormat,omitempty"`
+	DetachKeys           string                      `json:"detachKeys,omitempty"`
+	CredentialsStore     string                      `json:"credsStore,omitempty"`
+	CredentialHelpers    map[string]string           `json:"credHelpers,omitempty"`
+	Filename             string                      `json:"-"` // Note: for internal use only
+	ServiceInspectFormat string                      `json:"serviceInspectFormat,omitempty"`
+	ServicesFormat       string                      `json:"servicesFormat,omitempty"`
+	TasksFormat          string                      `json:"tasksFormat,omitempty"`
+	SecretFormat         string                      `json:"secretFormat,omitempty"`
+}
+
+// LegacyLoadFromReader reads the non-nested configuration data given and sets up the
+// auth config information with given directory and populates the receiver object
+func (configFile *ConfigFile) LegacyLoadFromReader(configData io.Reader) error {
+	b, err := ioutil.ReadAll(configData)
+	if err != nil {
+		return err
+	}
+
+	if err := json.Unmarshal(b, &configFile.AuthConfigs); err != nil {
+		arr := strings.Split(string(b), "\n")
+		if len(arr) < 2 {
+			return errors.Errorf("The Auth config file is empty")
+		}
+		authConfig := types.AuthConfig{}
+		origAuth := strings.Split(arr[0], " = ")
+		if len(origAuth) != 2 {
+			return errors.Errorf("Invalid Auth config file")
+		}
+		authConfig.Username, authConfig.Password, err = decodeAuth(origAuth[1])
+		if err != nil {
+			return err
+		}
+		authConfig.ServerAddress = defaultIndexserver
+		configFile.AuthConfigs[defaultIndexserver] = authConfig
+	} else {
+		for k, authConfig := range configFile.AuthConfigs {
+			authConfig.Username, authConfig.Password, err = decodeAuth(authConfig.Auth)
+			if err != nil {
+				return err
+			}
+			authConfig.Auth = ""
+			authConfig.ServerAddress = k
+			configFile.AuthConfigs[k] = authConfig
+		}
+	}
+	return nil
+}
+
+// LoadFromReader reads the configuration data given and sets up the auth config
+// information with given directory and populates the receiver object
+func (configFile *ConfigFile) LoadFromReader(configData io.Reader) error {
+	if err := json.NewDecoder(configData).Decode(&configFile); err != nil {
+		return err
+	}
+	var err error
+	for addr, ac := range configFile.AuthConfigs {
+		ac.Username, ac.Password, err = decodeAuth(ac.Auth)
+		if err != nil {
+			return err
+		}
+		ac.Auth = ""
+		ac.ServerAddress = addr
+		configFile.AuthConfigs[addr] = ac
+	}
+	return nil
+}
+
+// ContainsAuth returns whether there is authentication configured
+// in this file or not.
+func (configFile *ConfigFile) ContainsAuth() bool {
+	return configFile.CredentialsStore != "" ||
+		len(configFile.CredentialHelpers) > 0 ||
+		len(configFile.AuthConfigs) > 0
+}
+
+// SaveToWriter encodes and writes out all the authorization information to
+// the given writer
+func (configFile *ConfigFile) SaveToWriter(writer io.Writer) error {
+	// Encode sensitive data into a new/temp struct
+	tmpAuthConfigs := make(map[string]types.AuthConfig, len(configFile.AuthConfigs))
+	for k, authConfig := range configFile.AuthConfigs {
+		authCopy := authConfig
+		// encode and save the authstring, while blanking out the original fields
+		authCopy.Auth = encodeAuth(&authCopy)
+		authCopy.Username = ""
+		authCopy.Password = ""
+		authCopy.ServerAddress = ""
+		tmpAuthConfigs[k] = authCopy
+	}
+
+	saveAuthConfigs := configFile.AuthConfigs
+	configFile.AuthConfigs = tmpAuthConfigs
+	defer func() { configFile.AuthConfigs = saveAuthConfigs }()
+
+	data, err := json.MarshalIndent(configFile, "", "\t")
+	if err != nil {
+		return err
+	}
+	_, err = writer.Write(data)
+	return err
+}
+
+// Save encodes and writes out all the authorization information
+func (configFile *ConfigFile) Save() error {
+	if configFile.Filename == "" {
+		return errors.Errorf("Can't save config with empty filename")
+	}
+
+	if err := os.MkdirAll(filepath.Dir(configFile.Filename), 0700); err != nil {
+		return err
+	}
+	f, err := os.OpenFile(configFile.Filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return configFile.SaveToWriter(f)
+}
+
+// encodeAuth creates a base64 encoded string to containing authorization information
+func encodeAuth(authConfig *types.AuthConfig) string {
+	if authConfig.Username == "" && authConfig.Password == "" {
+		return ""
+	}
+
+	authStr := authConfig.Username + ":" + authConfig.Password
+	msg := []byte(authStr)
+	encoded := make([]byte, base64.StdEncoding.EncodedLen(len(msg)))
+	base64.StdEncoding.Encode(encoded, msg)
+	return string(encoded)
+}
+
+// decodeAuth decodes a base64 encoded string and returns username and password
+func decodeAuth(authStr string) (string, string, error) {
+	if authStr == "" {
+		return "", "", nil
+	}
+
+	decLen := base64.StdEncoding.DecodedLen(len(authStr))
+	decoded := make([]byte, decLen)
+	authByte := []byte(authStr)
+	n, err := base64.StdEncoding.Decode(decoded, authByte)
+	if err != nil {
+		return "", "", err
+	}
+	if n > decLen {
+		return "", "", errors.Errorf("Something went wrong decoding auth config")
+	}
+	arr := strings.SplitN(string(decoded), ":", 2)
+	if len(arr) != 2 {
+		return "", "", errors.Errorf("Invalid auth configuration file")
+	}
+	password := strings.Trim(arr[1], "\x00")
+	return arr[0], password, nil
+}

--- a/api/runner/func_logger.go
+++ b/api/runner/func_logger.go
@@ -5,8 +5,8 @@ import (
 	"io"
 
 	"context"
-	"github.com/Sirupsen/logrus"
-	"github.com/iron-io/runner/common"
+	"github.com/c0ze/runner/common"
+	"github.com/sirupsen/logrus"
 )
 
 type FuncLogger interface {

--- a/api/runner/metric_logger.go
+++ b/api/runner/metric_logger.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"time"
 
-	"github.com/Sirupsen/logrus"
-	"github.com/iron-io/runner/common"
+	"github.com/c0ze/runner/common"
+	"github.com/sirupsen/logrus"
 )
 
 type MetricLogger interface {

--- a/api/runner/runner.go
+++ b/api/runner/runner.go
@@ -13,13 +13,13 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/c0ze/runner/common"
+	"github.com/c0ze/runner/drivers"
+	driverscommon "github.com/c0ze/runner/drivers"
+	"github.com/c0ze/runner/drivers/docker"
+	"github.com/c0ze/runner/drivers/mock"
 	"github.com/iron-io/functions/api/runner/task"
-	"github.com/iron-io/runner/common"
-	"github.com/iron-io/runner/drivers"
-	driverscommon "github.com/iron-io/runner/drivers"
-	"github.com/iron-io/runner/drivers/docker"
-	"github.com/iron-io/runner/drivers/mock"
+	"github.com/sirupsen/logrus"
 )
 
 type Runner struct {

--- a/api/runner/task.go
+++ b/api/runner/task.go
@@ -25,7 +25,7 @@ func init() {
 	if regsettings == "" {
 		u, err := user.Current()
 		if err == nil {
-			var config configfile.ConfigFile
+			var config ConfigFile
 			cfile, err := os.Open(filepath.Join(u.HomeDir, ".docker", "config.json"))
 			if err != nil {
 				return

--- a/api/runner/task.go
+++ b/api/runner/task.go
@@ -9,10 +9,9 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/c0ze/runner/drivers"
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/iron-io/functions/api/runner/task"
-	"github.com/iron-io/runner/drivers"
-	"github.com/moby/moby/cli/config/configfile"
 )
 
 var registries dockerRegistries

--- a/api/runner/task/task.go
+++ b/api/runner/task/task.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"time"
 
-	"github.com/iron-io/runner/drivers"
+	"github.com/c0ze/runner/drivers"
 )
 
 type Config struct {

--- a/api/runner/worker.go
+++ b/api/runner/worker.go
@@ -8,10 +8,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/c0ze/runner/drivers"
 	"github.com/iron-io/functions/api/runner/protocol"
 	"github.com/iron-io/functions/api/runner/task"
-	"github.com/iron-io/runner/drivers"
+	"github.com/sirupsen/logrus"
 )
 
 // hot functions - theory of operation

--- a/api/server/apps_create.go
+++ b/api/server/apps_create.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/c0ze/runner/common"
 	"github.com/gin-gonic/gin"
 	"github.com/iron-io/functions/api/models"
-	"github.com/iron-io/runner/common"
 )
 
 func (s *Server) handleAppCreate(c *gin.Context) {

--- a/api/server/apps_delete.go
+++ b/api/server/apps_delete.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/c0ze/runner/common"
 	"github.com/gin-gonic/gin"
 	"github.com/iron-io/functions/api"
 	"github.com/iron-io/functions/api/models"
-	"github.com/iron-io/runner/common"
 )
 
 func (s *Server) handleAppDelete(c *gin.Context) {

--- a/api/server/apps_test.go
+++ b/api/server/apps_test.go
@@ -7,12 +7,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/gin-gonic/gin"
 	"github.com/iron-io/functions/api/datastore"
 	"github.com/iron-io/functions/api/models"
 	"github.com/iron-io/functions/api/mqs"
 	"github.com/iron-io/functions/api/runner/task"
+	"github.com/sirupsen/logrus"
 )
 
 func setLogBuffer() *bytes.Buffer {

--- a/api/server/apps_update.go
+++ b/api/server/apps_update.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/c0ze/runner/common"
 	"github.com/gin-gonic/gin"
 	"github.com/iron-io/functions/api"
 	"github.com/iron-io/functions/api/models"
-	"github.com/iron-io/runner/common"
 )
 
 func (s *Server) handleAppUpdate(c *gin.Context) {

--- a/api/server/error_response.go
+++ b/api/server/error_response.go
@@ -3,9 +3,9 @@ package server
 import (
 	"context"
 	"errors"
+	"github.com/c0ze/runner/common"
 	"github.com/gin-gonic/gin"
 	"github.com/iron-io/functions/api/models"
-	"github.com/iron-io/runner/common"
 	"net/http"
 )
 

--- a/api/server/init.go
+++ b/api/server/init.go
@@ -7,8 +7,8 @@ import (
 	"os/signal"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
 

--- a/api/server/middleware.go
+++ b/api/server/middleware.go
@@ -5,9 +5,9 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/gin-gonic/gin"
 	"github.com/iron-io/functions/api/models"
+	"github.com/sirupsen/logrus"
 )
 
 // Middleware is the interface required for implementing functions middlewar

--- a/api/server/routes_create.go
+++ b/api/server/routes_create.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/c0ze/runner/common"
 	"github.com/gin-gonic/gin"
 	"github.com/iron-io/functions/api"
 	"github.com/iron-io/functions/api/models"
-	"github.com/iron-io/runner/common"
 )
 
 func (s *Server) handleRouteCreate(c *gin.Context) {

--- a/api/server/routes_update.go
+++ b/api/server/routes_update.go
@@ -5,10 +5,10 @@ import (
 	"net/http"
 	"path"
 
+	"github.com/c0ze/runner/common"
 	"github.com/gin-gonic/gin"
 	"github.com/iron-io/functions/api"
 	"github.com/iron-io/functions/api/models"
-	"github.com/iron-io/runner/common"
 )
 
 func (s *Server) handleRouteUpdate(c *gin.Context) {

--- a/api/server/runner.go
+++ b/api/server/runner.go
@@ -12,15 +12,15 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/c0ze/runner/common"
 	"github.com/gin-gonic/gin"
 	"github.com/iron-io/functions/api"
 	"github.com/iron-io/functions/api/models"
 	"github.com/iron-io/functions/api/runner"
 	"github.com/iron-io/functions/api/runner/task"
 	f_common "github.com/iron-io/functions/common"
-	"github.com/iron-io/runner/common"
 	uuid "github.com/satori/go.uuid"
+	"github.com/sirupsen/logrus"
 )
 
 type runnerResponse struct {

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -11,7 +11,8 @@ import (
 	"path"
 	"sync"
 
-	"github.com/Sirupsen/logrus"
+	"cirello.io/supervisor"
+	"github.com/c0ze/runner/common"
 	"github.com/gin-gonic/gin"
 	"github.com/iron-io/functions/api"
 	"github.com/iron-io/functions/api/datastore"
@@ -20,9 +21,8 @@ import (
 	"github.com/iron-io/functions/api/runner"
 	"github.com/iron-io/functions/api/runner/task"
 	"github.com/iron-io/functions/api/server/internal/routecache"
-	"github.com/iron-io/runner/common"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
-	"github.com/ucirello/supervisor"
 )
 
 const (


### PR DESCRIPTION
What this PR does :

* [s/Sirupsen/sirupsen/](https://github.com/sirupsen/logrus/issues/451#issuecomment-264307105) (embrace lower case dep convention)
* use [my fork of iron-io/runner](https://github.com/c0ze/runner) (which also uses lowercase sirupsen import, and some other fixes) When iron-io runner is updated, we can switch back to iron-io/runner
* remove `"github.com/moby/moby/cli/config/configfile"` dependency and bring it into repository (that package does not exist anymore, also I couldn't find any other suitable replacement)
* fix `github.com/ucirello/supervisor` import as `cirello.io/supervisor` (we may want to fork this)

Previously we were on a hardcoded magic Gopkg.toml which was outdated (giving warning because of the [obsolete `dependencies` entries](https://github.com/golang/dep/issues/686))  We can now do a clean `dep init` and `dep ensure`.