### PR TITLE
Use GitHub's URL shortener

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ configuration options [here](docs/operating/options.md). If you are on Windows, 
 Install the IronFunctions CLI tool:
 
 ```sh
-curl -LSs https://goo.gl/VZrL8t | sh
+curl -LSs git.io/ironfn | sh
 ```
 
 This will download a shell script and execute it.  If the script asks for a password, that is because it invokes sudo.


### PR DESCRIPTION
git.io is GitHub's own URL shortener, which is guaranteed to only point to GitHub domains. This is safer and (IMO) more professional. Additionally, goo.gl will be deprecated *very* soon.